### PR TITLE
Relations removed and more

### DIFF
--- a/data/schema.sql
+++ b/data/schema.sql
@@ -52,7 +52,7 @@ CREATE TYPE msg_status AS ENUM (
 
 -- Offering status
 CREATE TYPE offer_status AS ENUM (
-	'empty', -- saved in DB, but not published to blockchain
+	'empty',  -- saved in DB, but not published to blockchain
 	'register', -- in registration or registered in blockchain
     'remove' -- being removed or already removed from blockchain
 );


### PR DESCRIPTION
1. Relation from `offering` to `users` table replaced by simple eth_address
2. Relation from `channel` to `users` table replaced by simple eth_address
3. New table `accounts` introduced to store local ethereum accounts data
4. Table `users` altered just to store address to public key relation
5. `offerings` and `endpoints` has new flag `is_local` that indicates whether object was authored locally or retrieved from external source.
4. minor comments fixes