### PR TITLE
Processor for top-level business-logic routines.

### DIFF
--- a/data/schema.go
+++ b/data/schema.go
@@ -275,6 +275,8 @@ const (
 	JobClientAfterCooperativeClose          = "clientAfterCooperativeClose"
 	JobAgentAfterCooperativeClose           = "agentAfterCooperativeClose"
 	JobAgentPreServiceCreate                = "agentPreServiceCreate"
+	JobAgentPreServiceSuspend               = "agentPreServiceSuspend"
+	JobAgentPreServiceUnsuspend             = "agentPreServiceUnsuspend"
 	JobClientPreServiceTerminate            = "clientPreServiceTerminate"
 	JobAgentPreServiceTerminate             = "agentPreServiceTerminate"
 	JobClientAfterServiceTerminate          = "clientAfterServiceTerminate"

--- a/data/test.go
+++ b/data/test.go
@@ -204,6 +204,18 @@ func SaveToTestDB(t *testing.T, db *reform.DB, recs ...reform.Record) {
 	CommitTestTX(t, tx)
 }
 
+// DeleteFromTestDB deletes records from test DB.
+func DeleteFromTestDB(t *testing.T, db *reform.DB, recs ...reform.Record) {
+	tx := BeginTestTX(t, db)
+	for _, v := range recs {
+		if err := tx.Delete(v); err != nil {
+			RollbackTestTX(t, tx)
+			t.Fatalf("failed to delete %T: %s", v, err)
+		}
+	}
+	CommitTestTX(t, tx)
+}
+
 // ReloadFromTestDB reloads records from test DB.
 func ReloadFromTestDB(t *testing.T, db *reform.DB, recs ...reform.Record) {
 	for _, v := range recs {
@@ -225,4 +237,40 @@ func CleanTestDB(t *testing.T, db *reform.DB) {
 		}
 	}
 	CommitTestTX(t, tx)
+}
+
+type TestFixture struct {
+	T        *testing.T
+	DB       *reform.DB
+	Product  *Product
+	Account  *Account
+	Template *Template
+	Offering *Offering
+	Channel  *Channel
+}
+
+func NewTestFixture(t *testing.T, db *reform.DB) *TestFixture {
+	prod := NewTestProduct()
+	acc := NewTestAccount(TestPassword)
+	tmpl := NewTestTemplate(TemplateOffer)
+	off := NewTestOffering(acc.EthAddr, prod.ID, tmpl.ID)
+	ch := NewTestChannel(
+		acc.EthAddr, acc.EthAddr, off.ID, 0, 0, ChannelActive)
+
+	InsertToTestDB(t, db, prod, acc, tmpl, off, ch)
+
+	return &TestFixture{
+		T:        t,
+		DB:       db,
+		Product:  prod,
+		Account:  acc,
+		Template: tmpl,
+		Offering: off,
+		Channel:  ch,
+	}
+}
+
+func (f *TestFixture) Close() {
+	DeleteFromTestDB(f.T, f.DB, f.Channel,
+		f.Offering, f.Template, f.Account, f.Product)
 }

--- a/job/queue.go
+++ b/job/queue.go
@@ -88,6 +88,16 @@ func NewQueue(conf *Config, logger *util.Logger, db *reform.DB,
 	}
 }
 
+// Logger is an associated util.Logger instance.
+func (q *Queue) Logger() *util.Logger {
+	return q.logger
+}
+
+// DB is an associated reform.DB instance.
+func (q *Queue) DB() *reform.DB {
+	return q.db
+}
+
 func (q *Queue) checkDuplicated(j *data.Job) error {
 	_, err := q.db.SelectOneFrom(data.JobTable,
 		"WHERE related_id = $1 AND type = $2", j.RelatedID, j.Type)

--- a/job/queue_test.go
+++ b/job/queue_test.go
@@ -42,7 +42,7 @@ func add(t *testing.T, queue *Queue, job *data.Job, expected error) {
 		if err == nil {
 			queue.db.Delete(job)
 		}
-		util.ExpectResult(t, "Add", expected, err)
+		util.TestExpectResult(t, "Add", expected, err)
 	}
 }
 
@@ -83,7 +83,7 @@ func TestHandlerNotFound(t *testing.T) {
 	add(t, queue, job, nil)
 	defer db.Delete(job)
 
-	util.ExpectResult(t, "Process", ErrHandlerNotFound, queue.Process())
+	util.TestExpectResult(t, "Process", ErrHandlerNotFound, queue.Process())
 }
 
 func waitForJob(queue *Queue, job *data.Job, ch chan<- error) {
@@ -125,8 +125,8 @@ func TestFailure(t *testing.T) {
 
 	ch := make(chan error)
 	go waitForJob(queue, job, ch)
-	util.ExpectResult(t, "Process", ErrQueueClosed, queue.Process())
-	util.ExpectResult(t, "waitForJob", nil, <-ch)
+	util.TestExpectResult(t, "Process", ErrQueueClosed, queue.Process())
+	util.TestExpectResult(t, "waitForJob", nil, <-ch)
 	if job.Status != data.JobDone {
 		t.Fatalf("job status is not done: %s", job.Status)
 	}
@@ -135,11 +135,11 @@ func TestFailure(t *testing.T) {
 	job.Status = data.JobActive
 	handlerMap[data.JobClientPreChannelCreate] =
 		makeHandler(conf.Job.TryLimit + 1)
-	util.ExpectResult(t, "Save", nil, db.Save(job))
+	util.TestExpectResult(t, "Save", nil, db.Save(job))
 
 	go waitForJob(queue, job, ch)
-	util.ExpectResult(t, "Process", ErrQueueClosed, queue.Process())
-	util.ExpectResult(t, "waitForJob", nil, <-ch)
+	util.TestExpectResult(t, "Process", ErrQueueClosed, queue.Process())
+	util.TestExpectResult(t, "waitForJob", nil, <-ch)
 	if job.Status != data.JobFailed {
 		t.Fatalf("job status is not failed: %s", job.Status)
 	}
@@ -186,7 +186,7 @@ func TestStress(t *testing.T) {
 	}
 
 	queue.Close()
-	util.ExpectResult(t, "Process", ErrQueueClosed, <-ch2)
+	util.TestExpectResult(t, "Process", ErrQueueClosed, <-ch2)
 }
 
 func TestMain(m *testing.M) {

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/privatix/dappctrl/execsrv"
 	"github.com/privatix/dappctrl/job"
 	"github.com/privatix/dappctrl/pay"
+	"github.com/privatix/dappctrl/proc"
 	"github.com/privatix/dappctrl/sesssrv"
 	"github.com/privatix/dappctrl/somc"
 	"github.com/privatix/dappctrl/util"
@@ -28,6 +29,7 @@ type ethConfig struct {
 	GethURL       string
 	TruffleAPIURL string
 }
+
 type config struct {
 	AgentServer   *uisrv.Config
 	Eth           *ethConfig
@@ -35,6 +37,7 @@ type config struct {
 	Job           *job.Config
 	Log           *util.LogConfig
 	PayServer     *pay.Config
+	Proc          *proc.Config
 	SessionServer *sesssrv.Config
 	SOMC          *somc.Config
 }
@@ -44,6 +47,7 @@ func newConfig() *config {
 		DB:            data.NewDBConfig(),
 		Job:           job.NewConfig(),
 		Log:           util.NewLogConfig(),
+		Proc:          proc.NewConfig(),
 		SessionServer: sesssrv.NewConfig(),
 		SOMC:          somc.NewConfig(),
 	}

--- a/proc/channel.go
+++ b/proc/channel.go
@@ -1,0 +1,128 @@
+package proc
+
+import (
+	"time"
+
+	reform "gopkg.in/reform.v1"
+
+	"github.com/privatix/dappctrl/data"
+)
+
+type transition = map[string]struct{}
+
+var (
+	activateTransitions = transition{
+		data.ServicePending:   struct{}{},
+		data.ServiceSuspended: struct{}{},
+	}
+	suspendTransitions = transition{
+		data.ServiceActive: struct{}{},
+	}
+	terminateTransitions = transition{
+		data.ServicePending:   struct{}{},
+		data.ServiceActive:    struct{}{},
+		data.ServiceSuspended: struct{}{},
+	}
+)
+
+func checkJobExists(tx *reform.TX, rel, ty string) error {
+	var err error
+	if len(ty) != 0 {
+		_, err = tx.SelectOneFrom(data.JobTable,
+			"WHERE status = $1 AND related_id = $2 AND type = $3",
+			data.JobActive, rel, ty)
+		if err == nil {
+			return ErrSameJobExists
+		}
+
+	} else {
+		_, err = tx.SelectOneFrom(data.JobTable,
+			"WHERE status = $1 AND related_id = $2",
+			data.JobActive, rel)
+		if err == nil {
+			return ErrActiveJobsExist
+		}
+	}
+
+	if err == reform.ErrNoRows {
+		return nil
+	}
+
+	return err
+}
+
+func cancelJobs(tx *reform.TX, rel string) error {
+	_, err := tx.Exec(`
+		UPDATE jobs
+		   SET status = $1
+		 WHERE status = $2 AND related_id = $3`,
+		data.JobCanceled, data.JobActive, rel)
+	return err
+}
+
+func (p *Processor) alterServiceStatus(id, jobCreator, jobType,
+	jobTypeToCheck string, trans transition, cancel bool) (string, error) {
+	tx, err := p.queue.DB().Begin()
+	if err != nil {
+		return "", err
+	}
+	defer tx.Rollback()
+
+	var ch data.Channel
+	err = tx.SelectOneTo(&ch, "WHERE id = $1 FOR UPDATE", id)
+	if err != nil {
+		return "", err
+	}
+
+	if _, ok := trans[ch.ServiceStatus]; !ok {
+		return "", ErrBadServiceStatus
+	}
+
+	if err := checkJobExists(tx, ch.ID, jobTypeToCheck); err != nil {
+		return "", err
+	}
+
+	if cancel {
+		if err := cancelJobs(tx, ch.ID); err != nil {
+			return "", err
+		}
+	}
+
+	j := &data.Job{
+		Type:        jobType,
+		RelatedID:   ch.ID,
+		RelatedType: data.JobChannel,
+		CreatedAt:   time.Now(),
+		CreatedBy:   jobCreator,
+	}
+
+	if err = p.queue.Add(j); err != nil {
+		return "", err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", err
+	}
+
+	return j.ID, nil
+}
+
+// SuspendChannel tries to suspend a given channel.
+func (p *Processor) SuspendChannel(id, jobCreator string) (string, error) {
+	return p.alterServiceStatus(id, jobCreator,
+		data.JobAgentPreServiceSuspend, "", suspendTransitions, false)
+}
+
+// ActivateChannel tries to activate a given channel.
+func (p *Processor) ActivateChannel(id, jobCreator string) (string, error) {
+	return p.alterServiceStatus(id, jobCreator,
+		data.JobAgentPreServiceUnsuspend, "", activateTransitions,
+		false)
+}
+
+// TerminateChannel tries to terminate a given channel.
+func (p *Processor) TerminateChannel(id, jobCreator string) (string, error) {
+	return p.alterServiceStatus(id, jobCreator,
+		data.JobAgentPreServiceTerminate,
+		data.JobAgentPreServiceTerminate, terminateTransitions, true)
+}

--- a/proc/channel_test.go
+++ b/proc/channel_test.go
@@ -1,0 +1,135 @@
+// +build !noproctest
+
+package proc
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	reform "gopkg.in/reform.v1"
+
+	"github.com/privatix/dappctrl/data"
+	"github.com/privatix/dappctrl/job"
+	"github.com/privatix/dappctrl/util"
+)
+
+var (
+	conf struct {
+		DB   *data.DBConfig
+		Job  *job.Config
+		Log  *util.LogConfig
+		Proc *Config
+	}
+
+	db   *reform.DB
+	proc *Processor
+)
+
+func newTestJob(channel string) *data.Job {
+	return &data.Job{
+		ID:          util.NewUUID(),
+		Status:      data.JobActive,
+		RelatedType: data.JobChannel,
+		RelatedID:   channel,
+		CreatedBy:   data.JobUser,
+	}
+}
+
+type channelActionFunc func(id, jobCreator string) (string, error)
+
+func testChannelAction(t *testing.T, channelAction channelActionFunc,
+	funcName, jobType, badServiceStatus, goodServiceStatus,
+	jobTypeToCheck string, cancel bool) {
+	_, err := channelAction(util.NewUUID(), data.JobUser)
+	util.TestExpectResult(t, funcName, reform.ErrNoRows, err)
+
+	fxt := data.NewTestFixture(t, db)
+	defer fxt.Close()
+
+	fxt.Channel.ServiceStatus = badServiceStatus
+	data.SaveToTestDB(t, db, fxt.Channel)
+	_, err = channelAction(fxt.Channel.ID, data.JobUser)
+	util.TestExpectResult(t, funcName, ErrBadServiceStatus, err)
+
+	job := newTestJob(fxt.Channel.ID)
+
+	expected := ErrActiveJobsExist
+	if len(jobTypeToCheck) != 0 {
+		job.Type = jobTypeToCheck
+		expected = ErrSameJobExists
+	}
+
+	fxt.Channel.ServiceStatus = goodServiceStatus
+	data.SaveToTestDB(t, db, fxt.Channel, job)
+	defer data.DeleteFromTestDB(t, db, job)
+
+	_, err = channelAction(fxt.Channel.ID, data.JobUser)
+	util.TestExpectResult(t, funcName, expected, err)
+
+	if len(jobTypeToCheck) != 0 {
+		job.Type = data.JobAgentPreServiceSuspend
+	} else {
+		job.Status = data.JobDone
+	}
+	data.SaveToTestDB(t, db, job)
+
+	before := time.Now()
+	id, err := channelAction(fxt.Channel.ID, data.JobBCMonitor)
+	after := time.Now()
+	util.TestExpectResult(t, funcName, nil, err)
+
+	if len(jobTypeToCheck) != 0 {
+		data.ReloadFromTestDB(t, db, job)
+		if job.Status != data.JobCanceled {
+			t.Fatalf("job wasn't cancelled")
+		}
+	}
+
+	job = &data.Job{ID: id}
+	defer data.DeleteFromTestDB(t, db, job)
+
+	data.ReloadFromTestDB(t, db, job)
+	if job.Type != jobType || job.RelatedID != fxt.Channel.ID ||
+		job.RelatedType != data.JobChannel ||
+		job.CreatedAt.Before(before) || job.CreatedAt.After(after) ||
+		job.CreatedBy != data.JobBCMonitor {
+		t.Fatalf("bad job data")
+	}
+}
+
+func TestSuspendChannel(t *testing.T) {
+	testChannelAction(t, proc.SuspendChannel, "SuspendChannel",
+		data.JobAgentPreServiceSuspend, data.ServiceSuspended,
+		data.ServiceActive, "", false)
+}
+
+func TestActivateChannel(t *testing.T) {
+	testChannelAction(t, proc.ActivateChannel, "ActivateChannel",
+		data.JobAgentPreServiceUnsuspend, data.ServiceActive,
+		data.ServiceSuspended, "", false)
+}
+
+func TestTerminateChannel(t *testing.T) {
+	testChannelAction(t, proc.TerminateChannel, "TerminateChannel",
+		data.JobAgentPreServiceTerminate, data.ServiceTerminated,
+		data.ServiceSuspended, data.JobAgentPreServiceTerminate, true)
+}
+
+func TestMain(m *testing.M) {
+	conf.DB = data.NewDBConfig()
+	conf.Job = job.NewConfig()
+	conf.Log = util.NewLogConfig()
+	conf.Proc = NewConfig()
+	util.ReadTestConfig(&conf)
+
+	logger := util.NewTestLogger(conf.Log)
+
+	db = data.NewTestDB(conf.DB, logger)
+	defer data.CloseDB(db)
+
+	queue := job.NewQueue(conf.Job, logger, db, nil)
+	proc = NewProcessor(conf.Proc, queue)
+
+	os.Exit(m.Run())
+}

--- a/proc/processor.go
+++ b/proc/processor.go
@@ -1,0 +1,38 @@
+package proc
+
+import (
+	"errors"
+
+	"github.com/privatix/dappctrl/job"
+)
+
+// Config is processor configuration.
+type Config struct {
+}
+
+// NewConfig creates a default processor configuration.
+func NewConfig() *Config {
+	return &Config{}
+}
+
+// Processor encapsulates a set of top-level business logic routines.
+type Processor struct {
+	conf  *Config
+	queue *job.Queue
+}
+
+// NewProcessor creates a new processor.
+func NewProcessor(
+	conf *Config, queue *job.Queue) *Processor {
+	return &Processor{
+		conf:  conf,
+		queue: queue,
+	}
+}
+
+// Processor-specific errors.
+var (
+	ErrBadServiceStatus = errors.New("bad service status")
+	ErrActiveJobsExist  = errors.New("active jobs exist")
+	ErrSameJobExists    = errors.New("same jobs exists")
+)

--- a/util/test.go
+++ b/util/test.go
@@ -30,8 +30,8 @@ func NewTestLogger(conf *LogConfig) *Logger {
 	return logger
 }
 
-// ExpectResult compares two errors and fails a test if they don't match.
-func ExpectResult(t *testing.T, op string, expected, actual error) {
+// TestExpectResult compares two errors and fails a test if they don't match.
+func TestExpectResult(t *testing.T, op string, expected, actual error) {
 	sameContent := expected != nil && actual != nil &&
 		expected.Error() == actual.Error()
 


### PR DESCRIPTION
This change adds support for channel suspension, activation and termination (not including the corresponding job handlers).

Resolves **BV-232**.