### PR TITLE
OpenVPN adapter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Prepare a `dappctrl` database instance:
 ```bash
 psql -U postgres -f $DAPPCTRL_DIR/data/settings.sql
 psql -U postgres -d dappctrl -f $DAPPCTRL_DIR/data/schema.sql
-psql -U postgres -d dappctrl -f $DAPPCTRL_DIR/data/test_data.sql
 ```
 
 Make a copy of `dappctrl.config.json`:
@@ -66,10 +65,10 @@ Modify `dappctrl.config.local.json` if you need non-default configuration and ru
 dappctrl -config=$DAPPCTRL_DIR/dappctrl.config.local.json
 ```
 
-Build `OpenVPN` session trigger:
+Build `OpenVPN` service adapter:
 
 ```bash
-go install $DAPPCTRL/tool/dapptrig
+go install $DAPPCTRL/svc/dappvpn
 ```
 
 ## Using docker
@@ -79,7 +78,8 @@ We have prepared two images and a compose file to make it easier to run app and 
 There are 3 services in compose file:
 
 1. `db` — uses public `postgres` image
-1. `vpn` — image `privatix/dapp-vpn-server` is an openvpn that uses `dapptrig` for auth, connect and disconnect
+1. `vpn` — image `privatix/dapp-vpn-server` is an openvpn with attached
+`dappvpn`.
 1. `dappctrl` — image `privatix/dappctrl` is a main controller app
 
 If you want to develop `dappctrl` then it is convenient to run its dependencies using `docker`, but controller itself at your host machine:

--- a/dappctrl-test.config.json
+++ b/dappctrl-test.config.json
@@ -8,6 +8,28 @@
         "ServerStartupDelay": 10
     },
 
+    "BillingTest": {
+        "Offer": {
+            "MaxUnit": 900,
+            "MaxInactiveTimeSec": 10,
+            "UnitPrice": 1,
+            "BigLag": 10000,
+            "SmallLag": 1
+        },
+        "Session": {
+            "UnitsUsed": 300,
+            "EmptyUnitsUsed":0,
+            "SecondsConsumed": 300,
+            "EmptySecondsConsumed":0
+        },
+        "Channel": {
+            "SmallDeposit":1,
+            "MidDeposit":100,
+            "BigDeposit":1000,
+            "EmptyBalance":0
+        }
+    },
+
     "DB": {
         "Conn": {
             "dbname": "dappctrl",
@@ -16,6 +38,26 @@
             "host": "localhost",
             "port": "5432"
         }
+    },
+
+    "EptTest": {
+        "ExportConfigKeys": [ "proto", "cipher", "ping-restart", "ping",
+            "connect-retry", "ca", "comp-lzo", "keepalive" ],
+        "ValidHash": [
+            "0x89f45a588f06d542b16020dd657486c7d163db03a2d599e4a606f8eb459e38b1",
+            "89f45a588f06d542b16020dd657486c7d163db03a2d599e4a606f8eb459e38b1"],
+        "InvalidHash": [
+            "",
+            "0x89f45a588f06d542b16020dd657486c7d163db03a2d599e4a606f8eb459e38b",
+            "0x89f45a588f06d542b16020dd657486c7d163db03a2d599e4a606f8eb459e38b11",
+            "0x89f45a588f06d542b16020dd657486c7d163db03a2d599e4a606f8eb459e38g1"],
+        "ValidHost": ["privatix.io:443", "127.0.0.1:443"],
+        "InvalidHost": ["privatix.io:44C", "priv#tix.io:443", "privatix.io%443"],
+        "ConfValidCaValid": "conf.valid.ca.valid",
+        "ConfInvalid": "conf.invalid",
+        "ConfValidCaInvalid": "conf.valid.ca.invalid",
+        "ConfValidCaEmpty": "conf.valid.ca.empty",
+        "ConfValidCaNotExist": "conf.valid.ca.notexist"
     },
 
     "Eth": {
@@ -73,45 +115,12 @@
         "ServerStartupDelay": 10
     },
 
-    "BillingTest": {
-        "Offer": {
-            "MaxUnit": 900,
-            "MaxInactiveTimeSec": 10,
-            "UnitPrice": 1,
-            "BigLag": 10000,
-            "SmallLag": 1
-        },
-        "Session": {
-            "UnitsUsed": 300,
-            "EmptyUnitsUsed":0,
-            "SecondsConsumed": 300,
-            "EmptySecondsConsumed":0
-        },
-        "Channel": {
-            "SmallDeposit":1,
-            "MidDeposit":100,
-            "BigDeposit":1000,
-            "EmptyBalance":0
-        }
+    "VPNMonitor": {
+        "Addr": "localhost:7505",
+        "ByteCountPeriod": 5
     },
 
-    "EptTest": {
-        "ExportConfigKeys": [ "proto", "cipher", "ping-restart", "ping",
-            "connect-retry", "ca", "comp-lzo", "keepalive" ],
-        "ValidHash": [
-            "0x89f45a588f06d542b16020dd657486c7d163db03a2d599e4a606f8eb459e38b1",
-            "89f45a588f06d542b16020dd657486c7d163db03a2d599e4a606f8eb459e38b1"],
-        "InvalidHash": [
-            "",
-            "0x89f45a588f06d542b16020dd657486c7d163db03a2d599e4a606f8eb459e38b",
-            "0x89f45a588f06d542b16020dd657486c7d163db03a2d599e4a606f8eb459e38b11",
-            "0x89f45a588f06d542b16020dd657486c7d163db03a2d599e4a606f8eb459e38g1"],
-        "ValidHost": ["privatix.io:443", "127.0.0.1:443"],
-        "InvalidHost": ["privatix.io:44C", "priv#tix.io:443", "privatix.io%443"],
-        "ConfValidCaValid": "conf.valid.ca.valid",
-        "ConfInvalid": "conf.invalid",
-        "ConfValidCaInvalid": "conf.valid.ca.invalid",
-        "ConfValidCaEmpty": "conf.valid.ca.empty",
-        "ConfValidCaNotExist": "conf.valid.ca.notexist"
+    "VPNMonitorTest": {
+        "ServerStartupDelay": 10
     }
 }

--- a/data/test_data.sql
+++ b/data/test_data.sql
@@ -1,0 +1,37 @@
+BEGIN TRANSACTION;
+
+-- Test data for integration testing of dappvpn.
+
+INSERT INTO products (id, name, usage_rep_type, is_server, salt, password,
+    client_ident)
+VALUES ('4b26dc82-ffb6-4ff1-99d8-f0eaac0b0532', 'Test VPN service', 'total',
+    true, 6012867121110302348, '7U9gC4AZsSZ9E8NabVkw8nHRlFCJe0o_Yh9qMlIaGAg=',
+    'by_channel_id');
+
+INSERT INTO accounts (id, eth_addr, public_key, private_key, name, ptc_balance,
+    psc_balance, eth_balance)
+VALUES ('e8b17880-8ee5-4fc1-afb2-e6900655d8d5', '', '', '', 'Test channel',
+    0, 0, '');
+
+INSERT INTO templates (id, hash, raw, kind)
+VALUES ('58fbe052-3f34-4b17-88c0-1121a8cf9336', '', '{}', 'offer');
+
+INSERT INTO offerings (id, is_local, tpl, product, hash, status, offer_status,
+    block_number_updated, agent, signature, service_name, country, supply,
+    unit_name, unit_type, billing_type, setup_price, unit_price, min_units,
+    max_unit, billing_interval, max_billing_unit_lag, max_suspended_time,
+    free_units)
+VALUES ('32000ae1-f752-4d55-8d58-22d05ef08803', true,
+    '58fbe052-3f34-4b17-88c0-1121a8cf9336',
+    '4b26dc82-ffb6-4ff1-99d8-f0eaac0b0532', '', 'msg_channel_published',
+    'register', 1, '', '', 'VPN', 'US', 1, 'megabyte', 'units', 'prepaid', 1,
+    1, 1, 100, 1, 0, 0, 0);
+
+INSERT INTO channels (id, is_local, agent, client, offering, block,
+    channel_status, service_status, total_deposit, salt, password,
+    receipt_balance, receipt_signature)
+VALUES ('ae5deac9-44c3-4840-bdff-ca9de58c89f4', true, '', '',
+    '32000ae1-f752-4d55-8d58-22d05ef08803', 1, 'active', 'active', 1,
+    6012867121110302348, '7U9gC4AZsSZ9E8NabVkw8nHRlFCJe0o_Yh9qMlIaGAg=', 1, 1);
+
+END TRANSACTION;

--- a/proc/channel.go
+++ b/proc/channel.go
@@ -34,7 +34,6 @@ func checkJobExists(tx *reform.TX, rel, ty string) error {
 		if err == nil {
 			return ErrSameJobExists
 		}
-
 	} else {
 		_, err = tx.SelectOneFrom(data.JobTable,
 			"WHERE status = $1 AND related_id = $2",

--- a/sesssrv/client.go
+++ b/sesssrv/client.go
@@ -9,7 +9,7 @@ import (
 
 // Post posts a request with given arguments and returns a response result.
 func Post(conf *srv.Config, username, password, path string,
-	args interface{}, result interface{}) error {
+	args, result interface{}) error {
 	data, err := json.Marshal(args)
 	if err != nil {
 		return err

--- a/svc/dappvpn/dappvpn.config.json
+++ b/svc/dappvpn/dappvpn.config.json
@@ -1,0 +1,20 @@
+{
+    "ChannelDir": ".",
+
+    "Log": {
+        "Level": "info"
+    },
+
+    "Monitor": {
+        "Addr": "localhost:7505",
+        "ByteCountPeriod": 5
+    },
+
+    "Password": "secret",
+    "Product": "4b26dc82-ffb6-4ff1-99d8-f0eaac0b0532",
+
+    "Server": {
+        "Addr": "localhost:8000",
+        "TLS": null
+    }
+}

--- a/svc/dappvpn/main.go
+++ b/svc/dappvpn/main.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/privatix/dappctrl/sesssrv"
+	"github.com/privatix/dappctrl/svc/dappvpn/mon"
+	"github.com/privatix/dappctrl/util"
+	"github.com/privatix/dappctrl/util/srv"
+)
+
+type config struct {
+	ChannelDir string // Directory for common-name -> channel mappings.
+	Log        *util.LogConfig
+	Monitor    *mon.Config
+	Password   string // HTTP basic auth. password.
+	Product    string // HTTP basic auth. username.
+	Server     *srv.Config
+}
+
+func newConfig() *config {
+	return &config{
+		ChannelDir: ".",
+		Log:        util.NewLogConfig(),
+		Monitor:    mon.NewConfig(),
+		Server:     srv.NewConfig(),
+	}
+}
+
+var (
+	conf   *config
+	logger *util.Logger
+)
+
+func main() {
+	var err error
+
+	conf = newConfig()
+	name := util.ExeDirJoin("dappvpn.config.json")
+	if err := util.ReadJSONFile(name, &conf); err != nil {
+		log.Fatalf("failed to read configuration: %s\n", err)
+	}
+
+	logger, err = util.NewLogger(conf.Log)
+	if err != nil {
+		log.Fatalf("failed to create logger: %s\n", err)
+	}
+
+	switch os.Getenv("script_type") {
+	case "user-pass-verify":
+		handleAuth()
+	case "client-connect":
+		handleConnect()
+	case "client-disconnect":
+		handleDisconnect()
+	default:
+		handleMonitor()
+	}
+}
+
+func handleAuth() {
+	user, pass := getCreds()
+	args := sesssrv.AuthArgs{ClientID: user, Password: pass}
+
+	err := sesssrv.Post(conf.Server,
+		conf.Product, conf.Password, sesssrv.PathAuth, args, nil)
+	if err != nil {
+		logger.Fatal("failed to auth: %s", err)
+	}
+
+	storeChannel(user)
+}
+
+func handleConnect() {
+	port, err := strconv.Atoi(os.Getenv("trusted_port"))
+	if err != nil || port <= 0 || port > 0xFFFF {
+		logger.Fatal("bad trusted_port value")
+	}
+
+	args := sesssrv.StartArgs{
+		ClientID:   loadChannel(),
+		ClientIP:   os.Getenv("trusted_ip"),
+		ClientPort: uint16(port),
+	}
+
+	err = sesssrv.Post(conf.Server,
+		conf.Product, conf.Password, sesssrv.PathStart, args, nil)
+	if err != nil {
+		logger.Fatal("failed to start session: %s", err)
+	}
+}
+
+func handleDisconnect() {
+	down, err := strconv.ParseUint(os.Getenv("bytes_sent"), 10, 64)
+	if err != nil || down < 0 {
+		log.Fatalf("bad bytes_sent value")
+	}
+
+	up, err := strconv.ParseUint(os.Getenv("bytes_received"), 10, 64)
+	if err != nil || up < 0 {
+		log.Fatalf("bad bytes_received value")
+	}
+
+	args := sesssrv.StopArgs{
+		ClientID: loadChannel(),
+		Units:    down + up,
+	}
+
+	err = sesssrv.Post(conf.Server,
+		conf.Product, conf.Password, sesssrv.PathStop, args, nil)
+	if err != nil {
+		logger.Fatal("failed to stop session: %s", err)
+	}
+}
+
+func handleMonitor() {
+	handleByteCount := func(ch string, up, down uint64) bool {
+		args := sesssrv.UpdateArgs{
+			ClientID: ch,
+			Units:    down + up,
+		}
+
+		err := sesssrv.Post(conf.Server, conf.Product,
+			conf.Password, sesssrv.PathUpdate, args, nil)
+
+		if err != nil {
+			logger.Info("failed to update session %s: %s", ch, err)
+			return false
+		}
+
+		return true
+	}
+
+	monitor := mon.NewMonitor(conf.Monitor, logger, handleByteCount)
+
+	logger.Fatal("failed to monitor vpn traffic: %s",
+		monitor.MonitorTraffic())
+}

--- a/svc/dappvpn/misc.go
+++ b/svc/dappvpn/misc.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bufio"
+	"encoding/base64"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+const chanPerm = 0644
+
+func commonName() string {
+	cn := os.Getenv("common_name")
+	if len(cn) == 0 {
+		logger.Fatal("empty common_name")
+	}
+	return base64.URLEncoding.EncodeToString([]byte(cn))
+}
+
+func storeChannel(ch string) {
+	name := filepath.Join(conf.ChannelDir, commonName())
+	err := ioutil.WriteFile(name, []byte(ch), chanPerm)
+	if err != nil {
+		logger.Fatal("failed to store channel: %s", err)
+	}
+}
+
+func loadChannel() string {
+	name := filepath.Join(conf.ChannelDir, commonName())
+	data, err := ioutil.ReadFile(name)
+	if err != nil {
+		logger.Fatal("failed to load channel: %s", err)
+	}
+	return string(data)
+}
+
+func getCreds() (string, string) {
+	user := os.Getenv("username")
+	pass := os.Getenv("password")
+
+	if len(user) != 0 && len(pass) != 0 {
+		return user, pass
+	}
+
+	if len(os.Args) < 2 {
+		logger.Fatal("no filename passed to read credentials")
+	}
+
+	file, err := os.Open(os.Args[1])
+	if err != nil {
+		logger.Fatal("failed to open file with credentials: %s", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Scan()
+	user = scanner.Text()
+	scanner.Scan()
+	pass = scanner.Text()
+
+	if err := scanner.Err(); err != nil {
+		logger.Fatal("failed to read file with credentials: %s", err)
+	}
+
+	return user, pass
+}

--- a/svc/dappvpn/mon/monitor.go
+++ b/svc/dappvpn/mon/monitor.go
@@ -1,0 +1,213 @@
+package mon
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/privatix/dappctrl/util"
+)
+
+// Config is a configuration for OpenVPN monitor.
+type Config struct {
+	Addr            string
+	ByteCountPeriod uint // In seconds.
+}
+
+// NewConfig creates a default configuration for OpenVPN monitor.
+func NewConfig() *Config {
+	return &Config{
+		Addr:            "localhost:7505",
+		ByteCountPeriod: 5,
+	}
+}
+
+type client struct {
+	channel    string
+	commonName string
+}
+
+// Monitor is an OpenVPN monitor for observation of consumed VPN traffic and
+// for killing client VPN sessions.
+type Monitor struct {
+	conf            *Config
+	logger          *util.Logger
+	handleByteCount HandleByteCountFunc
+	conn            net.Conn
+	mtx             sync.Mutex // To guard writing.
+	clients         map[uint]client
+}
+
+// HandleByteCountFunc is a byte count handler. If it returns false, then the
+// monitor kills the corresponding session.
+type HandleByteCountFunc func(ch string, up, down uint64) bool
+
+// NewMonitor creates a new OpenVPN monitor.
+func NewMonitor(conf *Config, logger *util.Logger,
+	handleByteCount HandleByteCountFunc) *Monitor {
+	return &Monitor{
+		conf:            conf,
+		logger:          logger,
+		handleByteCount: handleByteCount,
+	}
+}
+
+// Close immediately closes the monitor making MonitorTraffic() to return.
+func (m *Monitor) Close() error {
+	if m.conn != nil {
+		return m.conn.Close()
+	}
+	return nil
+}
+
+// Monitor errors.
+var (
+	ErrServerOutdated = errors.New("server outdated")
+)
+
+// MonitorTraffic connects to OpenVPN management interfaces and starts
+// monitoring VPN traffic.
+func (m *Monitor) MonitorTraffic() error {
+	var err error
+	if m.conn, err = net.Dial("tcp", m.conf.Addr); err != nil {
+		return err
+	}
+	defer m.conn.Close()
+
+	reader := bufio.NewReader(m.conn)
+
+	if err := m.requestClients(); err != nil {
+		return err
+	}
+
+	if err := m.setByteCountPeriod(); err != nil {
+		return err
+	}
+
+	for {
+		str, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+
+		if err = m.processReply(str); err != nil {
+			return err
+		}
+	}
+}
+
+func (m *Monitor) write(cmd string) error {
+	m.mtx.Lock()
+	_, err := m.conn.Write([]byte(cmd + "\n"))
+	m.mtx.Unlock()
+	return err
+}
+
+func (m *Monitor) requestClients() error {
+	m.logger.Info("requesting updated client list")
+	return m.write("status 2")
+}
+
+func (m *Monitor) setByteCountPeriod() error {
+	return m.write(fmt.Sprintf("bytecount %d", m.conf.ByteCountPeriod))
+}
+
+func (m *Monitor) killSession(cn string) error {
+	return m.write(fmt.Sprintf("kill %s", cn))
+}
+
+const (
+	prefixClientListHeader  = "HEADER,CLIENT_LIST,"
+	prefixClientList        = "CLIENT_LIST,"
+	prefixByteCount         = ">BYTECOUNT_CLI:"
+	prefixClientEstablished = ">CLIENT:ESTABLISHED,"
+	prefixError             = "ERROR: "
+)
+
+func (m *Monitor) processReply(s string) error {
+	m.logger.Debug("openvpn raw: %s", s)
+
+	if strings.HasPrefix(s, prefixClientListHeader) {
+		m.clients = make(map[uint]client)
+		return nil
+	}
+
+	if strings.HasPrefix(s, prefixClientList) {
+		return m.processClientList(s[len(prefixClientList):])
+	}
+
+	if strings.HasPrefix(s, prefixByteCount) {
+		return m.processByteCount(s[len(prefixByteCount):])
+	}
+
+	if strings.HasPrefix(s, prefixClientEstablished) {
+		return m.requestClients()
+	}
+
+	if strings.HasPrefix(s, prefixError) {
+		m.logger.Error("openvpn error: %s", s[len(prefixError):])
+	}
+
+	return nil
+}
+
+func split(s string) []string {
+	return strings.Split(strings.TrimRight(s, "\r\n"), ",")
+}
+
+func (m *Monitor) processClientList(s string) error {
+	sp := split(s)
+	if len(sp) < 10 {
+		return ErrServerOutdated
+	}
+
+	cid, err := strconv.ParseUint(sp[9], 10, 32)
+	if err != nil {
+		return err
+	}
+
+	m.clients[uint(cid)] = client{sp[8], sp[0]}
+	m.logger.Info("openvpn client found: cid %d, chan %s, cn %s",
+		cid, sp[8], sp[0])
+
+	return nil
+}
+
+func (m *Monitor) processByteCount(s string) error {
+	sp := split(s)
+
+	cid, err := strconv.ParseUint(sp[0], 10, 32)
+	if err != nil {
+		return err
+	}
+
+	down, err := strconv.ParseUint(sp[1], 10, 64)
+	if err != nil {
+		return err
+	}
+
+	up, err := strconv.ParseUint(sp[2], 10, 64)
+	if err != nil {
+		return err
+	}
+
+	cl, ok := m.clients[uint(cid)]
+	if !ok {
+		return m.requestClients()
+	}
+
+	m.logger.Info("openvpn byte count for chan %s: up %d, down %d",
+		cl.channel, up, down)
+
+	go func() {
+		if !m.handleByteCount(cl.channel, up, down) {
+			m.killSession(cl.commonName)
+		}
+	}()
+
+	return nil
+}

--- a/svc/dappvpn/mon/monitor_test.go
+++ b/svc/dappvpn/mon/monitor_test.go
@@ -1,0 +1,213 @@
+// +build !nosvcdappvpnmontest
+
+package mon
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/privatix/dappctrl/util"
+)
+
+type testConfig struct {
+	ServerStartupDelay uint // In milliseconds.
+}
+
+func newTestConfig() *testConfig {
+	return &testConfig{
+		ServerStartupDelay: 10,
+	}
+}
+
+var conf struct {
+	Log            *util.LogConfig
+	VPNMonitor     *Config
+	VPNMonitorTest *testConfig
+}
+
+var logger *util.Logger
+
+func connect(t *testing.T,
+	handleByteCount HandleByteCountFunc) (net.Conn, <-chan error) {
+	lst, err := net.Listen("tcp", conf.VPNMonitor.Addr)
+	if err != nil {
+		t.Fatalf("failed to listen: %s", err)
+	}
+	defer lst.Close()
+
+	time.Sleep(time.Duration(conf.VPNMonitorTest.ServerStartupDelay) *
+		time.Millisecond)
+
+	ch := make(chan error)
+	go func() {
+		mon := NewMonitor(conf.VPNMonitor, logger, handleByteCount)
+		ch <- mon.MonitorTraffic()
+		mon.Close()
+	}()
+
+	var conn net.Conn
+	if conn, err = lst.Accept(); err != nil {
+		t.Fatalf("failed to accept: %s", err)
+	}
+
+	return conn, ch
+}
+
+func expectExit(t *testing.T, ch <-chan error, expected error) {
+	err := <-ch
+
+	_, neterr := err.(net.Error)
+	disconn := neterr || err == io.EOF
+
+	if (disconn && expected != nil) || (!disconn && err != expected) {
+		t.Fatalf("unexpected monitor error: %s", err)
+	}
+}
+
+func exit(t *testing.T, conn net.Conn, ch <-chan error) {
+	conn.Close()
+	expectExit(t, ch, nil)
+}
+
+func send(t *testing.T, conn net.Conn, str string) {
+	if _, err := conn.Write([]byte(str + "\n")); err != nil {
+		t.Fatalf("failed to send to monitor: %s", err)
+	}
+}
+
+func receive(t *testing.T, reader *bufio.Reader) string {
+	str, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("failed to receive from monitor: %s", err)
+	}
+	return strings.TrimRight(str, "\r\n")
+}
+
+func assertNothingToReceive(t *testing.T, conn net.Conn, reader *bufio.Reader) {
+	conn.SetReadDeadline(time.Now().Add(time.Millisecond))
+
+	str, err := reader.ReadString('\n')
+	if err == nil {
+		t.Fatalf("unexpected message received: %s", str)
+	}
+
+	if neterr, ok := err.(net.Error); !ok || !neterr.Timeout() {
+		t.Fatalf("non-timeout error: %s", err)
+	}
+}
+
+func ignoreByteCount(ch string, up, down uint64) bool {
+	return true
+}
+
+func TestOldOpenVPN(t *testing.T) {
+	conn, ch := connect(t, ignoreByteCount)
+	defer conn.Close()
+
+	send(t, conn, prefixClientListHeader)
+	send(t, conn, prefixClientList+",,,,,,,,")
+
+	expectExit(t, ch, ErrServerOutdated)
+}
+
+func TestInitFlow(t *testing.T) {
+	conn, ch := connect(t, ignoreByteCount)
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+
+	if str := receive(t, reader); str != "status 2" {
+		t.Fatalf("unexpected status command: %s", str)
+	}
+
+	cmd := fmt.Sprintf("bytecount %d", conf.VPNMonitor.ByteCountPeriod)
+	if str := receive(t, reader); str != cmd {
+		t.Fatalf("unexpected bytecount command: %s", str)
+	}
+
+	exit(t, conn, ch)
+}
+
+const (
+	cid         = 0
+	up, down    = 1024, 2048
+	commonName  = "Common-Name"
+	testChannel = "Test-Channel"
+)
+
+func sendByteCount(t *testing.T, conn net.Conn) {
+	send(t, conn, prefixClientListHeader)
+	send(t, conn, fmt.Sprintf("%s%s,,,,,,,,%s,%d",
+		prefixClientList, commonName, testChannel, cid))
+	send(t, conn, fmt.Sprintf("%s%d,%d,%d", prefixByteCount, cid, down, up))
+}
+
+func TestByteCount(t *testing.T) {
+	type data struct {
+		ch       string
+		up, down uint64
+	}
+
+	out := make(chan data)
+	handleByteCount := func(ch string, up, down uint64) bool {
+		out <- data{ch, up, down}
+		return true
+	}
+
+	conn, ch := connect(t, handleByteCount)
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+
+	receive(t, reader)
+	receive(t, reader)
+
+	sendByteCount(t, conn)
+
+	data2 := <-out
+	if data2.ch != testChannel || data2.down != down || data2.up != up {
+		t.Fatalf("wrong handler arguments")
+	}
+
+	assertNothingToReceive(t, conn, reader)
+
+	exit(t, conn, ch)
+}
+
+func TestKill(t *testing.T) {
+	handleByteCount := func(ch string, up, down uint64) bool {
+		return false
+	}
+
+	conn, ch := connect(t, handleByteCount)
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+
+	receive(t, reader)
+	receive(t, reader)
+
+	sendByteCount(t, conn)
+
+	if str := receive(t, reader); str != "kill "+commonName {
+		t.Fatalf("kill expected, but received: %s", str)
+	}
+
+	exit(t, conn, ch)
+}
+
+func TestMain(m *testing.M) {
+	conf.Log = util.NewLogConfig()
+	conf.VPNMonitor = NewConfig()
+	util.ReadTestConfig(&conf)
+
+	logger = util.NewTestLogger(conf.Log)
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
**This change contains**:
1. OpenVPN adapter executable in `svc/dappvpn`.
2. OpenVPN monitor package with the corresponding tests.

**Usage**:

1. Make sure you have a properly configured `dappvpn.config.json` in a same directory as the `dappvpn` executable.

2. Run OpenVPN server with `dappvpn` passed as a session trigger:
```
auth-user-pass-verify /path/to/dappvpn via-file
client-connect /path/to/dappvpn
client-disconnect /path/to/dappvpn
script-security 3
management <ip> <port>
```
3. Run `dappvpn` in the background to monitor OpenVPN sessions.

**Resolves BV-230**.