### PR TITLE
add client support to proc/channel

### DIFF
--- a/agent/bill/monitor.go
+++ b/agent/bill/monitor.go
@@ -227,17 +227,17 @@ func (m *Monitor) processRound() error {
 }
 
 func (m *Monitor) suspendService(uuid string) error {
-	_, err := m.pr.SuspendChannel(uuid, jobCreator)
+	_, err := m.pr.SuspendChannel(uuid, jobCreator, "agent")
 	return err
 }
 
 func (m *Monitor) terminateService(uuid string) error {
-	_, err := m.pr.TerminateChannel(uuid, jobCreator)
+	_, err := m.pr.TerminateChannel(uuid, jobCreator, "agent")
 	return err
 }
 
 func (m *Monitor) unsuspendService(uuid string) error {
-	_, err := m.pr.ActivateChannel(uuid, jobCreator)
+	_, err := m.pr.ActivateChannel(uuid, jobCreator, "agent")
 	return err
 }
 

--- a/agent/bill/monitor.go
+++ b/agent/bill/monitor.go
@@ -227,17 +227,17 @@ func (m *Monitor) processRound() error {
 }
 
 func (m *Monitor) suspendService(uuid string) error {
-	_, err := m.pr.SuspendChannel(uuid, jobCreator, "agent")
+	_, err := m.pr.SuspendChannel(uuid, jobCreator, true)
 	return err
 }
 
 func (m *Monitor) terminateService(uuid string) error {
-	_, err := m.pr.TerminateChannel(uuid, jobCreator, "agent")
+	_, err := m.pr.TerminateChannel(uuid, jobCreator, true)
 	return err
 }
 
 func (m *Monitor) unsuspendService(uuid string) error {
-	_, err := m.pr.ActivateChannel(uuid, jobCreator, "agent")
+	_, err := m.pr.ActivateChannel(uuid, jobCreator, true)
 	return err
 }
 

--- a/client/bill/monitor.go
+++ b/client/bill/monitor.go
@@ -133,7 +133,7 @@ func (m *Monitor) Close() {
 
 func (m *Monitor) processChannel(ch *data.Channel) error {
 	if ch.ReceiptBalance == ch.TotalDeposit {
-		_, err := m.pr.TerminateChannel(ch.ID, data.JobBillingChecker)
+		_, err := m.pr.TerminateChannel(ch.ID, data.JobBillingChecker, "client")
 		if err != nil {
 			if err != proc.ErrSameJobExists {
 				return err

--- a/client/bill/monitor.go
+++ b/client/bill/monitor.go
@@ -116,7 +116,7 @@ L:
 	m.exit = nil
 	m.mtx.Unlock()
 
-	logger.Info("%s", ret)
+	m.logger.Info("%s", ret)
 	return ret
 }
 
@@ -133,7 +133,7 @@ func (m *Monitor) Close() {
 
 func (m *Monitor) processChannel(ch *data.Channel) error {
 	if ch.ReceiptBalance == ch.TotalDeposit {
-		_, err := m.pr.TerminateChannel(ch.ID, data.JobBillingChecker, "client")
+		_, err := m.pr.TerminateChannel(ch.ID, data.JobBillingChecker, false)
 		if err != nil {
 			if err != proc.ErrSameJobExists {
 				return err

--- a/data/schema.go
+++ b/data/schema.go
@@ -277,6 +277,8 @@ const (
 	JobClientPreUncooperativeClose          = "clientPreUncooperativeClose"
 	JobClientAfterUncooperativeClose        = "clientAfterUncooperativeClose"
 	JobClientAfterCooperativeClose          = "clientAfterCooperativeClose"
+	JobClientPreServiceSuspend              = "clientPreServiceSuspend"
+	JobClientPreServiceUnsuspend            = "clientPreServiceUnsuspend"
 	JobClientPreServiceTerminate            = "clientPreServiceTerminate"
 	JobClientAfterServiceTerminate          = "clientAfterServiceTerminate"
 	JobClientPreEndpointMsgSOMCGet          = "clientPreEndpointMsgSOMCGet"

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -557,39 +557,39 @@ func scheduleTest(t *testing.T, td *testData, queue *mockQueue,
 	})
 	// offering events containing agent address should be ignored
 
-// TODO: uncomment, when client job handler are completed
-/*
-	insertEvent(t, db, nextBlock(), 0,
-		eth.EthOfferingCreated,
-		someAddress,         // agent
-		td.offering[2].Hash, // offering hash
-		minDepositVal,       // min deposit
-	)
-	queue.expect(unrelatedOfferingCreated, func(j *data.Job) bool {
-		return j.Type == data.JobClientAfterOfferingMsgBCPublish
-	})
+	// TODO: uncomment, when client job handler are completed
+	/*
+		insertEvent(t, db, nextBlock(), 0,
+			eth.EthOfferingCreated,
+			someAddress,         // agent
+			td.offering[2].Hash, // offering hash
+			minDepositVal,       // min deposit
+		)
+		queue.expect(unrelatedOfferingCreated, func(j *data.Job) bool {
+			return j.Type == data.JobClientAfterOfferingMsgBCPublish
+		})
 
-	insertEvent(t, db, nextBlock(), 0,
-		eth.EthOfferingPoppedUp,
-		someAddress,         // agent
-		td.offering[2].Hash, // offering hash
-	)
-	queue.expect(clientOfferingPoppedUp, func(j *data.Job) bool {
-		return j.Type == data.JobClientAfterOfferingMsgBCPublish
-	})
+		insertEvent(t, db, nextBlock(), 0,
+			eth.EthOfferingPoppedUp,
+			someAddress,         // agent
+			td.offering[2].Hash, // offering hash
+		)
+		queue.expect(clientOfferingPoppedUp, func(j *data.Job) bool {
+			return j.Type == data.JobClientAfterOfferingMsgBCPublish
+		})
 
-	// Tick here on purpose, so that not all events are ignored because
-	// the offering's been deleted.
-	ticker.tick()
-	queue.awaitCompletion(time.Second)
+		// Tick here on purpose, so that not all events are ignored because
+		// the offering's been deleted.
+		ticker.tick()
+		queue.awaitCompletion(time.Second)
 
-	insertEvent(t, db, nextBlock(), 0,
-		eth.EthOfferingDeleted,
-		someAddress,         // agent
-		td.offering[2].Hash, // offering hash
-	)
-	// should ignore the deletion event
-*/
+		insertEvent(t, db, nextBlock(), 0,
+			eth.EthOfferingDeleted,
+			someAddress,         // agent
+			td.offering[2].Hash, // offering hash
+		)
+		// should ignore the deletion event
+	*/
 	insertEvent(t, db, nextBlock(), 0,
 		eth.EthOfferingPoppedUp,
 		someAddress,         // agent
@@ -606,52 +606,52 @@ func scheduleTest(t *testing.T, td *testData, queue *mockQueue,
 	queue.expect(agentAfterChannelCreated, func(j *data.Job) bool {
 		return j.Type == data.JobAgentAfterChannelCreate
 	})
-// TODO: uncomment, when client job handler are completed
-/*
-	el := insertEvent(t, db, nextBlock(), 0,
-		eth.EthDigestChannelToppedUp,
-		td.addr[0],          // agent
-		someAddress,         // client
-		td.offering[1].Hash, // offering
-	)
-	bs, err := mon.pscABI.Events[LogChannelTopUp].Inputs.NonIndexed().Pack(
-		uint32(td.channel[1].Block),
-		new(big.Int),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	el.Data = data.FromBytes(bs)
-	if err := db.Save(el); err != nil {
-		t.Fatal(err)
-	}
-	// channel does not exist, thus event ignored
+	// TODO: uncomment, when client job handler are completed
+	/*
+		el := insertEvent(t, db, nextBlock(), 0,
+			eth.EthDigestChannelToppedUp,
+			td.addr[0],          // agent
+			someAddress,         // client
+			td.offering[1].Hash, // offering
+		)
+		bs, err := mon.pscABI.Events[LogChannelTopUp].Inputs.NonIndexed().Pack(
+			uint32(td.channel[1].Block),
+			new(big.Int),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		el.Data = data.FromBytes(bs)
+		if err := db.Save(el); err != nil {
+			t.Fatal(err)
+		}
+		// channel does not exist, thus event ignored
 
-	el = insertEvent(t, db, nextBlock(), 0,
-		eth.EthDigestChannelToppedUp,
-		someAddress,         // agent
-		td.addr[1],          // client
-		td.offering[1].Hash, // offering
-	)
+		el = insertEvent(t, db, nextBlock(), 0,
+			eth.EthDigestChannelToppedUp,
+			someAddress,         // agent
+			td.addr[1],          // client
+			td.offering[1].Hash, // offering
+		)
 
-	bs, err = mon.pscABI.Events[LogChannelTopUp].Inputs.NonIndexed().Pack(
-		uint32(td.channel[1].Block),
-		new(big.Int),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	el.Data = data.FromBytes(bs)
-	if err := db.Save(el); err != nil {
-		t.Fatal(err)
-	}
-	queue.expect(clientAfterChannelTopUp, func(j *data.Job) bool {
-		return j.Type == data.JobClientAfterChannelTopUp
-	})
+		bs, err = mon.pscABI.Events[LogChannelTopUp].Inputs.NonIndexed().Pack(
+			uint32(td.channel[1].Block),
+			new(big.Int),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		el.Data = data.FromBytes(bs)
+		if err := db.Save(el); err != nil {
+			t.Fatal(err)
+		}
+		queue.expect(clientAfterChannelTopUp, func(j *data.Job) bool {
+			return j.Type == data.JobClientAfterChannelTopUp
+		})
 
-	ticker.tick()
-	queue.awaitCompletion(time.Second)
-*/
+		ticker.tick()
+		queue.awaitCompletion(time.Second)
+	*/
 }
 
 func TestMonitorSchedule(t *testing.T) {

--- a/proc/channel.go
+++ b/proc/channel.go
@@ -108,21 +108,53 @@ func (p *Processor) alterServiceStatus(id, jobCreator, jobType,
 }
 
 // SuspendChannel tries to suspend a given channel.
-func (p *Processor) SuspendChannel(id, jobCreator string) (string, error) {
+func (p *Processor) SuspendChannel(id, jobCreator,
+	userType string)	(string, error) {
+	var jobType string
+	switch userType {
+	case "client":
+		jobType = data.JobClientPreServiceSuspend
+	case "agent":
+		jobType = data.JobAgentPreServiceSuspend
+	default:
+		panic("unsupported user type: " + userType)
+	}
+
 	return p.alterServiceStatus(id, jobCreator,
-		data.JobAgentPreServiceSuspend, "", suspendTransitions, false)
+		jobType, "", suspendTransitions, false)
 }
 
 // ActivateChannel tries to activate a given channel.
-func (p *Processor) ActivateChannel(id, jobCreator string) (string, error) {
+func (p *Processor) ActivateChannel(id, jobCreator,
+	userType string) (string, error) {
+	var jobType string
+	switch userType {
+	case "client":
+		jobType = data.JobClientPreServiceUnsuspend
+	case "agent":
+		jobType = data.JobAgentPreServiceUnsuspend
+	default:
+		panic("unsupported user type: " + userType)
+	}
+
 	return p.alterServiceStatus(id, jobCreator,
-		data.JobAgentPreServiceUnsuspend, "", activateTransitions,
+		jobType, "", activateTransitions,
 		false)
 }
 
 // TerminateChannel tries to terminate a given channel.
-func (p *Processor) TerminateChannel(id, jobCreator string) (string, error) {
+func (p *Processor) TerminateChannel(id, jobCreator,
+	userType string)	(string, error) {
+	var jobType string
+	switch userType {
+	case "client":
+		jobType = data.JobClientPreServiceTerminate
+	case "agent":
+		jobType = data.JobAgentPreServiceTerminate
+	default:
+		panic("unsupported user type: " + userType)
+	}
+
 	return p.alterServiceStatus(id, jobCreator,
-		data.JobAgentPreServiceTerminate,
-		data.JobAgentPreServiceTerminate, terminateTransitions, true)
+		jobType, jobType, terminateTransitions, true)
 }

--- a/proc/channel.go
+++ b/proc/channel.go
@@ -108,16 +108,13 @@ func (p *Processor) alterServiceStatus(id, jobCreator, jobType,
 }
 
 // SuspendChannel tries to suspend a given channel.
-func (p *Processor) SuspendChannel(id, jobCreator,
-	userType string)	(string, error) {
+func (p *Processor) SuspendChannel(id, jobCreator string,
+	agent bool) (string, error) {
 	var jobType string
-	switch userType {
-	case "client":
-		jobType = data.JobClientPreServiceSuspend
-	case "agent":
+	if agent {
 		jobType = data.JobAgentPreServiceSuspend
-	default:
-		panic("unsupported user type: " + userType)
+	} else {
+		jobType = data.JobClientPreServiceSuspend
 	}
 
 	return p.alterServiceStatus(id, jobCreator,
@@ -125,34 +122,27 @@ func (p *Processor) SuspendChannel(id, jobCreator,
 }
 
 // ActivateChannel tries to activate a given channel.
-func (p *Processor) ActivateChannel(id, jobCreator,
-	userType string) (string, error) {
+func (p *Processor) ActivateChannel(id, jobCreator string,
+	agent bool) (string, error) {
 	var jobType string
-	switch userType {
-	case "client":
-		jobType = data.JobClientPreServiceUnsuspend
-	case "agent":
+	if agent {
 		jobType = data.JobAgentPreServiceUnsuspend
-	default:
-		panic("unsupported user type: " + userType)
+	} else {
+		jobType = data.JobClientPreServiceUnsuspend
 	}
 
 	return p.alterServiceStatus(id, jobCreator,
-		jobType, "", activateTransitions,
-		false)
+		jobType, "", activateTransitions, false)
 }
 
 // TerminateChannel tries to terminate a given channel.
-func (p *Processor) TerminateChannel(id, jobCreator,
-	userType string)	(string, error) {
+func (p *Processor) TerminateChannel(id, jobCreator string,
+	agent bool) (string, error) {
 	var jobType string
-	switch userType {
-	case "client":
-		jobType = data.JobClientPreServiceTerminate
-	case "agent":
+	if agent {
 		jobType = data.JobAgentPreServiceTerminate
-	default:
-		panic("unsupported user type: " + userType)
+	} else {
+		jobType = data.JobClientPreServiceTerminate
 	}
 
 	return p.alterServiceStatus(id, jobCreator,

--- a/proc/processor/processor.go
+++ b/proc/processor/processor.go
@@ -1,0 +1,8 @@
+package processor
+
+// Processor encapsulates a set of top-level business logic routines.
+type Processor interface {
+	SuspendChannel(id, jobCreator string, agent bool) (string, error)
+	ActivateChannel(id, jobCreator string, agent bool) (string, error)
+	TerminateChannel(id, jobCreator string, agent bool) (string, error)
+}

--- a/proc/worker/worker.go
+++ b/proc/worker/worker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/privatix/dappctrl/job"
 	"github.com/privatix/dappctrl/messages/ept"
 	"github.com/privatix/dappctrl/messages/ept/config"
+	"github.com/privatix/dappctrl/proc/processor"
 	"github.com/privatix/dappctrl/somc"
 	"github.com/privatix/dappctrl/util"
 )
@@ -57,6 +58,7 @@ type Worker struct {
 	queue          *job.Queue
 	clientVPN      *config.Config
 	deployConfig   deployConfigFunc
+	processor      processor.Processor
 }
 
 // NewWorker returns new instance of worker.
@@ -94,4 +96,9 @@ func NewWorker(logger *util.Logger, db *reform.DB, somc *somc.Conn,
 // SetQueue sets queue for handlers.
 func (h *Worker) SetQueue(queue *job.Queue) {
 	h.queue = queue
+}
+
+// SetProcessor sets processor.
+func (h *Worker) SetProcessor(processor processor.Processor) {
+	h.processor = processor
 }


### PR DESCRIPTION
This PR add support to safely transition service status for Client. Before that only agent supported.