### PR TITLE
Service runner for the client controller mode.

### DIFF
--- a/client/svcrun/runner.go
+++ b/client/svcrun/runner.go
@@ -1,0 +1,197 @@
+package svcrun
+
+import (
+	"errors"
+	"os/exec"
+	"sync"
+
+	"gopkg.in/reform.v1"
+
+	"github.com/privatix/dappctrl/data"
+	"github.com/privatix/dappctrl/job"
+	"github.com/privatix/dappctrl/util"
+)
+
+// ServiceRunner errors.
+var (
+	ErrAlreadyStarted = errors.New("service already running")
+	ErrUnknownService = errors.New("unknown service type")
+	ErrNotRunning     = errors.New("not running")
+)
+
+// ServiceRunner starts and stops services.
+type ServiceRunner interface {
+	Start(channel string) error
+	IsRunning(channel string) (bool, error)
+	Stop(channel string) error
+	StopAll() error
+}
+
+// ServiceConfig is a service-specific configuration.
+type ServiceConfig struct {
+	Name   string   // Name of client adapter executable.
+	Args   []string // Client adapter arguments.
+	Single bool     // Whether to forbid multiple service instances.
+}
+
+// Config is a service runner configuration.
+type Config struct {
+	Services map[string]ServiceConfig
+}
+
+// NewConfig creates a new service runner configuration.
+func NewConfig() *Config {
+	return &Config{
+		Services: map[string]ServiceConfig{},
+	}
+}
+
+type newCmdFunc func(name string, args []string, channel string) *exec.Cmd
+
+type serviceRunner struct {
+	conf   *Config
+	logger *util.Logger
+	db     *reform.DB
+	queue  *job.Queue
+	newCmd newCmdFunc
+	mtx    sync.Mutex
+	cmds   map[string]*exec.Cmd
+}
+
+// NewServiceRunner creates a new service runner.
+func NewServiceRunner(conf *Config, logger *util.Logger,
+	db *reform.DB, queue *job.Queue) ServiceRunner {
+	newCmd := func(name string, args []string, channel string) *exec.Cmd {
+		return exec.Command(name, append(args, "-channel="+channel)...)
+	}
+
+	return &serviceRunner{
+		conf:   conf,
+		logger: logger,
+		db:     db,
+		queue:  queue,
+		newCmd: newCmd,
+		cmds:   make(map[string]*exec.Cmd),
+	}
+}
+
+// StopAll stops all the running services.
+func (r *serviceRunner) StopAll() error {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	var err error
+	for _, v := range r.cmds {
+		if err2 := v.Process.Kill(); err == nil {
+			err = err2
+		}
+	}
+
+	return err
+}
+
+// Start starts a service associated with a given channel.
+func (r *serviceRunner) Start(channel string) error {
+	conf, key, err := r.getKey(channel)
+	if err != nil {
+		return err
+	}
+
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	if _, ok := r.cmds[key]; ok {
+		return ErrAlreadyStarted
+	}
+
+	cmd := r.newCmd(conf.Name, conf.Args, channel)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	r.logger.Warn("service adapter for channel %s has started", channel)
+
+	r.cmds[key] = cmd
+
+	go r.wait(channel, key, cmd)
+
+	return nil
+}
+
+func (r *serviceRunner) getKey(channel string) (*ServiceConfig, string, error) {
+	var ch data.Channel
+	err := data.FindByPrimaryKeyTo(r.db.Querier, &ch, channel)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var offer data.Offering
+	err = data.FindByPrimaryKeyTo(r.db.Querier, &offer, ch.Offering)
+	if err != nil {
+		return nil, "", err
+	}
+
+	conf, ok := r.conf.Services[offer.ServiceName]
+	if !ok {
+		return nil, "", ErrUnknownService
+	}
+
+	if conf.Single {
+		return &conf, offer.ServiceName, nil
+	}
+
+	return &conf, channel, nil
+}
+
+func (r *serviceRunner) wait(channel, key string, cmd *exec.Cmd) {
+	r.logger.Warn("service adapter for channel %s has exited: %v",
+		channel, cmd.Wait())
+
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	delete(r.cmds, key)
+
+	if err := r.queue.Add(&data.Job{
+		Type:        data.JobClientPreServiceSuspend,
+		RelatedType: data.JobChannel,
+		RelatedID:   channel,
+		CreatedBy:   data.JobServiceAdapter,
+		Data:        []byte("{}"),
+	}); err != nil {
+		r.logger.Error("failed to add a job to the queue: %s", err)
+	}
+}
+
+// Stop stops an already started service.
+func (r *serviceRunner) Stop(channel string) error {
+	_, key, err := r.getKey(channel)
+	if err != nil {
+		return err
+	}
+
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	cmd, ok := r.cmds[key]
+	if !ok {
+		return ErrNotRunning
+	}
+
+	return cmd.Process.Kill()
+}
+
+// IsRunning returns whether a service for a given channel is running.
+func (r *serviceRunner) IsRunning(channel string) (bool, error) {
+	_, key, err := r.getKey(channel)
+	if err != nil {
+		return false, err
+	}
+
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	_, ok := r.cmds[key]
+
+	return ok, nil
+}

--- a/client/svcrun/runner_test.go
+++ b/client/svcrun/runner_test.go
@@ -1,0 +1,167 @@
+// +build !noclientsvcruntest
+
+package svcrun
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"gopkg.in/reform.v1"
+
+	"github.com/privatix/dappctrl/data"
+	"github.com/privatix/dappctrl/job"
+	"github.com/privatix/dappctrl/util"
+)
+
+type testConfig struct {
+	ExecPeriod time.Duration // Test process execution period, in milliseconds.
+}
+
+func newTestConfig() *testConfig {
+	return &testConfig{
+		ExecPeriod: 100,
+	}
+}
+
+var (
+	conf struct {
+		DB                *data.DBConfig
+		Log               *util.LogConfig
+		Job               *job.Config
+		ServiceRunner     *Config
+		ServiceRunnerTest *testConfig
+	}
+
+	logger *util.Logger
+	db     *reform.DB
+	queue  *job.Queue
+)
+
+func assertNotRunning(t *testing.T, runner *serviceRunner, channel string) {
+	running, err := runner.IsRunning(channel)
+	util.TestExpectResult(t, "Check if running", nil, err)
+	if running {
+		t.Fatalf("service is running")
+	}
+}
+
+func assertJobAdded(t *testing.T, channel string) {
+	var job data.Job
+	data.FindInTestDB(t, db, &job, "related_id", channel)
+	defer data.DeleteFromTestDB(t, db, &job)
+
+	if job.Type != data.JobClientPreServiceSuspend {
+		t.Fatalf("unexpected job type: %s", job.Type)
+	}
+}
+
+func newTestServiceRunner() *serviceRunner {
+	runner := NewServiceRunner(
+		conf.ServiceRunner, logger, db, queue).(*serviceRunner)
+
+	runner.newCmd = func(
+		name string, args []string, channel string) *exec.Cmd {
+		return exec.Command(name, args...)
+	}
+
+	return runner
+}
+
+func TestStart(t *testing.T) {
+	fxt := data.NewTestFixture(t, db)
+	defer fxt.Close()
+
+	runner := newTestServiceRunner()
+	defer runner.StopAll()
+
+	util.TestExpectResult(t, "Start service",
+		nil, runner.Start(fxt.Channel.ID))
+
+	time.Sleep(conf.ServiceRunnerTest.ExecPeriod * time.Millisecond / 2)
+
+	util.TestExpectResult(t, "Start service",
+		ErrAlreadyStarted, runner.Start(fxt.Channel.ID))
+
+	time.Sleep(conf.ServiceRunnerTest.ExecPeriod * time.Millisecond)
+
+	assertNotRunning(t, runner, fxt.Channel.ID)
+	assertJobAdded(t, fxt.Channel.ID)
+}
+
+func TestStop(t *testing.T) {
+	fxt := data.NewTestFixture(t, db)
+	defer fxt.Close()
+
+	runner := newTestServiceRunner()
+	defer runner.StopAll()
+
+	util.TestExpectResult(t, "Start service",
+		nil, runner.Start(fxt.Channel.ID))
+
+	time.Sleep(conf.ServiceRunnerTest.ExecPeriod * time.Millisecond / 3)
+
+	util.TestExpectResult(t, "Stop service",
+		nil, runner.Stop(fxt.Channel.ID))
+
+	time.Sleep(conf.ServiceRunnerTest.ExecPeriod * time.Millisecond / 3)
+
+	assertNotRunning(t, runner, fxt.Channel.ID)
+	assertJobAdded(t, fxt.Channel.ID)
+}
+
+func TestStopAll(t *testing.T) {
+	fxt := data.NewTestFixture(t, db)
+	defer fxt.Close()
+
+	ch := *fxt.Channel
+	ch.ID = util.NewUUID()
+	data.InsertToTestDB(t, db, &ch)
+	defer data.DeleteFromTestDB(t, db, &ch)
+
+	conf2 := conf.ServiceRunner
+	if sconf, ok := conf2.Services[fxt.Offering.ServiceName]; ok {
+		sconf.Single = false
+		conf2.Services = map[string]ServiceConfig{
+			fxt.Offering.ServiceName: sconf,
+		}
+	} else {
+		t.Fatalf("no service config found")
+	}
+
+	runner := newTestServiceRunner()
+
+	util.TestExpectResult(t, "Start service 1",
+		nil, runner.Start(fxt.Channel.ID))
+	util.TestExpectResult(t, "Start service 2", nil, runner.Start(ch.ID))
+
+	time.Sleep(conf.ServiceRunnerTest.ExecPeriod * time.Millisecond / 3)
+
+	runner.StopAll()
+
+	time.Sleep(conf.ServiceRunnerTest.ExecPeriod * time.Millisecond / 3)
+
+	assertNotRunning(t, runner, fxt.Channel.ID)
+	assertJobAdded(t, fxt.Channel.ID)
+	assertNotRunning(t, runner, ch.ID)
+	assertJobAdded(t, ch.ID)
+}
+
+func TestMain(m *testing.M) {
+	conf.DB = data.NewDBConfig()
+	conf.Log = util.NewLogConfig()
+	conf.Job = job.NewConfig()
+	conf.ServiceRunner = NewConfig()
+	conf.ServiceRunnerTest = newTestConfig()
+	util.ReadTestConfig(&conf)
+
+	logger = util.NewTestLogger(conf.Log)
+
+	db = data.NewTestDB(conf.DB, logger)
+	defer data.CloseDB(db)
+
+	queue = job.NewQueue(conf.Job, logger, db, nil)
+
+	os.Exit(m.Run())
+}

--- a/client/svcrun/test.go
+++ b/client/svcrun/test.go
@@ -1,0 +1,44 @@
+// +build !notest
+
+package svcrun
+
+// Mock methods.
+const (
+	MockStart     = iota
+	MockIsRunning = iota
+	MockStop      = iota
+	MockStopAll   = iota
+)
+
+// Mock is a ServiceRunner method handler.
+type Mock func(method int, channel string) (bool, error)
+
+// NewIdleMock returns a mock which does nothing.
+func NewIdleMock() Mock {
+	return func(method int, channel string) (bool, error) {
+		return false, nil
+	}
+}
+
+// Start is a mock implementation for the Start service runner method.
+func (m Mock) Start(channel string) error {
+	_, err := m(MockStart, channel)
+	return err
+}
+
+// IsRunning is a mock implementation for the IsRunning service runner method.
+func (m Mock) IsRunning(channel string) (bool, error) {
+	return m(MockIsRunning, channel)
+}
+
+// Stop is a mock implementation for the Stop service runner method.
+func (m Mock) Stop(channel string) error {
+	_, err := m(MockStop, channel)
+	return err
+}
+
+// StopAll is a mock implementation for the StopAll service runner method.
+func (m Mock) StopAll() error {
+	_, err := m(MockStopAll, "")
+	return err
+}

--- a/dappctrl-test.config.json
+++ b/dappctrl-test.config.json
@@ -156,6 +156,20 @@
         "TLS": null
     },
 
+    "ServiceRunner": {
+        "Services": {
+            "VPN": {
+                "Name": "sleep",
+                "Args": [".1"],
+                "Single": true
+            }
+        }
+    },
+
+    "ServiceRunnerTest": {
+        "ExecPeriod": 100
+    },
+
     "SessionServer": {
         "Addr": "localhost:8000",
         "TLS": null

--- a/dappctrl.config.json
+++ b/dappctrl.config.json
@@ -107,6 +107,16 @@
         "TLS": null
     },
 
+    "ServiceRunner": {
+        "Services": {
+            "VPN": {
+                "Name": "/root/go/bin/dappvpn",
+                "Args": ["-config=/opt/privatix/config/dappvpn.config.json"],
+                "Single": true
+            }
+        }
+    },
+
     "SessionServer": {
         "Addr": "localhost:8000",
         "TLS": null

--- a/dappctrl.prod.config.json
+++ b/dappctrl.prod.config.json
@@ -107,6 +107,16 @@
         "TLS": null
     },
 
+    "ServiceRunner": {
+        "Services": {
+            "VPN": {
+                "Name": "/root/go/bin/dappvpn",
+                "Args": ["-config=/opt/privatix/config/dappvpn.config.json"],
+                "Single": true
+            }
+        }
+    },
+
     "SessionServer": {
         "Addr": "localhost:8000",
         "TLS": null

--- a/data/schema.go
+++ b/data/schema.go
@@ -240,6 +240,7 @@ const (
 	JobBillingChecker = "billing_checker"
 	JobBCMonitor      = "bc_monitor"
 	JobTask           = "task"
+	JobServiceAdapter = "service_adapter"
 )
 
 // Job statuses.

--- a/data/schema.sql
+++ b/data/schema.sql
@@ -75,7 +75,8 @@ CREATE TYPE job_creator AS ENUM (
     'user', -- by user through UI
     'billing_checker', -- by billing checker procedure
     'bc_monitor', -- by blockchain monitor
-    'task' -- by another task
+    'task', -- by another task
+    'service_adapter' -- by service adapter
 );
 
 -- Job status.

--- a/data/test.go
+++ b/data/test.go
@@ -180,6 +180,7 @@ func NewTestOffering(agent, product, tpl string) *Offering {
 		BlockNumberUpdated: 1,
 		Template:           tpl,
 		Agent:              agent,
+		ServiceName:        "VPN",
 		Hash:               FromBytes(crypto.Keccak256(fakeMsg)),
 		Product:            product,
 		Supply:             1,

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 
+	"github.com/privatix/dappctrl/client/svcrun"
 	"github.com/privatix/dappctrl/data"
 	"github.com/privatix/dappctrl/eth/contract"
 	"github.com/privatix/dappctrl/execsrv"
@@ -44,6 +45,7 @@ type config struct {
 	PayAddress    string
 	Proc          *proc.Config
 	Report        *bugsnag.Config
+	ServiceRunner *svcrun.Config
 	SessionServer *sesssrv.Config
 	SOMC          *somc.Config
 	StaticPasword string
@@ -59,6 +61,7 @@ func newConfig() *config {
 		Log:           util.NewLogConfig(),
 		Proc:          proc.NewConfig(),
 		Report:        bugsnag.NewConfig(),
+		ServiceRunner: svcrun.NewConfig(),
 		SessionServer: sesssrv.NewConfig(),
 		SOMC:          somc.NewConfig(),
 		VPNClient:     vpncli.NewConfig(),
@@ -156,6 +159,9 @@ func main() {
 
 	queue := job.NewQueue(conf.Job, logger, db, handlers.HandlersMap(worker))
 	worker.SetQueue(queue)
+
+	runner := svcrun.NewServiceRunner(conf.ServiceRunner, logger, db, queue)
+	worker.SetRunner(runner)
 
 	pr := proc.NewProcessor(conf.Proc, queue)
 	worker.SetProcessor(pr)

--- a/proc/worker/client.go
+++ b/proc/worker/client.go
@@ -352,7 +352,9 @@ func (w *Worker) ClientPreServiceTerminate(job *data.Job) error {
 		return err
 	}
 
-	// TODO(maxim) Stop OpenVPN client via dappvpn.
+	if err := w.runner.Stop(ch.ID); err != nil {
+		w.logger.Info("failed to stop service: %s", err)
+	}
 
 	ch.ServiceStatus = data.ServiceTerminated
 	return data.Save(w.db.Querier, ch)
@@ -365,7 +367,9 @@ func (w *Worker) ClientPreServiceSuspend(job *data.Job) error {
 		return err
 	}
 
-	// TODO(maxim) Stop OpenVPN client via dappvpn (check & kill).
+	if err := w.runner.Stop(ch.ID); err != nil {
+		w.logger.Error("failed to stop service: %s", err)
+	}
 
 	ch.ServiceStatus = data.ServiceSuspended
 	return data.Save(w.db.Querier, ch)
@@ -378,7 +382,9 @@ func (w *Worker) ClientPreServiceUnsuspend(job *data.Job) error {
 		return err
 	}
 
-	// TODO(maxim) Start OpenVPN client via dappvpn.
+	if err := w.runner.Start(ch.ID); err != nil {
+		w.logger.Error("failed to start service: %s", err)
+	}
 
 	ch.ServiceStatus = data.ServiceActive
 	return data.Save(w.db.Querier, ch)

--- a/proc/worker/client_test.go
+++ b/proc/worker/client_test.go
@@ -10,6 +10,7 @@ import (
 
 	"gopkg.in/reform.v1"
 
+	"github.com/privatix/dappctrl/client/svcrun"
 	"github.com/privatix/dappctrl/data"
 	"github.com/privatix/dappctrl/messages"
 	"github.com/privatix/dappctrl/messages/ept"
@@ -500,6 +501,23 @@ func TestClientAfterCooperativeClose(t *testing.T) {
 	}
 }
 
+func runJobCheckingRunnerCall(t *testing.T, env *workerTest,
+	workerF func(*data.Job) error, job *data.Job, runnerMethod int) {
+	calledMethod := -1
+	var calledChannel string
+	env.worker.runner = svcrun.Mock(
+		func(method int, channel string) (bool, error) {
+			calledMethod, calledChannel = method, channel
+			return false, nil
+		})
+
+	runJob(t, workerF, job)
+
+	if calledMethod != runnerMethod || calledChannel != job.RelatedID {
+		t.Fatalf("unexpected service runner call arguments")
+	}
+}
+
 func TestClientPreServiceTerminate(t *testing.T) {
 	env := newWorkerTest(t)
 	defer env.close()
@@ -527,7 +545,8 @@ func TestClientPreServiceTerminate(t *testing.T) {
 	var job data.Job
 	env.findTo(t, &job, jobID)
 
-	runJob(t, env.worker.ClientPreServiceTerminate, &job)
+	runJobCheckingRunnerCall(t, env,
+		env.worker.ClientPreServiceTerminate, &job, svcrun.MockStop)
 
 	var ch data.Channel
 	env.findTo(t, &ch, fxt.Channel.ID)
@@ -580,7 +599,8 @@ func TestClientPreServiceSuspend(t *testing.T) {
 	env.findTo(t, &job, jobID)
 	defer env.deleteFromTestDB(t, &job)
 
-	runJob(t, env.worker.ClientPreServiceSuspend, &job)
+	runJobCheckingRunnerCall(t, env,
+		env.worker.ClientPreServiceSuspend, &job, svcrun.MockStop)
 
 	var ch data.Channel
 	env.findTo(t, &ch, fxt.Channel.ID)
@@ -632,7 +652,8 @@ func TestClientPreServiceUnsuspend(t *testing.T) {
 	env.findTo(t, &job, jobID)
 	defer env.deleteFromTestDB(t, &job)
 
-	runJob(t, env.worker.ClientPreServiceUnsuspend, &job)
+	runJobCheckingRunnerCall(t, env,
+		env.worker.ClientPreServiceUnsuspend, &job, svcrun.MockStart)
 
 	var ch data.Channel
 	env.findTo(t, &ch, fxt.Channel.ID)

--- a/proc/worker/worker.go
+++ b/proc/worker/worker.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	reform "gopkg.in/reform.v1"
 
+	"github.com/privatix/dappctrl/client/svcrun"
 	"github.com/privatix/dappctrl/data"
 	"github.com/privatix/dappctrl/eth/contract"
 	"github.com/privatix/dappctrl/job"
@@ -59,6 +60,7 @@ type Worker struct {
 	clientVPN      *config.Config
 	deployConfig   deployConfigFunc
 	processor      *proc.Processor
+	runner         svcrun.ServiceRunner
 }
 
 // NewWorker returns new instance of worker.
@@ -90,15 +92,21 @@ func NewWorker(logger *util.Logger, db *reform.DB, somc *somc.Conn,
 		somc:           somc,
 		deployConfig:   config.DeployConfig,
 		clientVPN:      clientVPN,
+		runner:         svcrun.NewIdleMock(),
 	}, nil
 }
 
-// SetQueue sets queue for handlers.
+// SetQueue sets a queue for handlers.
 func (w *Worker) SetQueue(queue *job.Queue) {
 	w.queue = queue
 }
 
-// SetProcessor sets processor.
+// SetProcessor sets a processor.
 func (w *Worker) SetProcessor(processor *proc.Processor) {
 	w.processor = processor
+}
+
+// SetRunner sets a service runner.
+func (w *Worker) SetRunner(runner svcrun.ServiceRunner) {
+	w.runner = runner
 }

--- a/sesssrv/start.go
+++ b/sesssrv/start.go
@@ -30,17 +30,27 @@ func (s *Server) handleStart(
 		return
 	}
 
-	s.Logger().Info("new client session from IP %s, port %d",
-		args.ClientIP, args.ClientPort)
+	s.Logger().Info("new client session for %s", args.ClientID)
 
 	now := time.Now()
+
+	var ip *string
+	if len(args.ClientIP) != 0 {
+		ip = pointer.ToString(args.ClientIP)
+	}
+
+	var port *uint16
+	if args.ClientPort != 0 {
+		port = pointer.ToUint16(args.ClientPort)
+	}
+
 	sess := data.Session{
 		ID:            util.NewUUID(),
 		Channel:       ch.ID,
 		Started:       now,
 		LastUsageTime: now,
-		ClientIP:      pointer.ToString(args.ClientIP),
-		ClientPort:    pointer.ToUint16(args.ClientPort),
+		ClientIP:      ip,
+		ClientPort:    port,
 	}
 	if err := s.db.Insert(&sess); err != nil {
 		s.Logger().Error("failed to insert session: %s", err)

--- a/svc/dappvpn/dappvpn.config.json
+++ b/svc/dappvpn/dappvpn.config.json
@@ -8,7 +8,15 @@
     "Monitor": {
         "Addr": "localhost:7505",
         "ByteCountPeriod": 5,
-        "Channel": "ae5deac9-44c3-4840-bdff-ca9de58c89f4"
+    },
+
+    "MonitorDelay": 1000,
+
+    "OpenVPN": {
+        "Name": "openvpn",
+        "Args": [],
+        "ConfigRoot": "/etc/openvpn/config",
+        "StartDelay": 1000
     },
 
     "Pusher": {


### PR DESCRIPTION
This change includes the following items:
1. Service runner type which allows to launch service adapters.
2. The corresponding mock and tests.
3. Dappvpn support for OpenVPN-client launching and monitoring.
4. ClientPreServiceTerminate/Suspend/Unsuspend jobs call runner.
5. Various minor imporvements and refactoring.

Resolves BV-338.