### PR TITLE
Guarantee to close adapters after exiting controller.

### DIFF
--- a/svc/dappvpn/main.go
+++ b/svc/dappvpn/main.go
@@ -242,19 +242,16 @@ func handleMonitor(confFile string) {
 		}()
 	}
 
-	var ovpn *os.Process
 	if len(channel) != 0 {
-		ovpn = launchOpenVPN()
+		ovpn := launchOpenVPN()
+		defer ovpn.Kill()
 		time.Sleep(conf.OpenVPN.StartDelay * time.Millisecond)
 	}
 
 	monitor := mon.NewMonitor(conf.Monitor, logger, handleSession, channel)
 
-	err := monitor.MonitorTraffic()
-	if ovpn != nil {
-		ovpn.Kill()
-	}
-	logger.Fatal("failed to monitor vpn traffic: %s", err)
+	logger.Fatal("failed to monitor vpn traffic: %s",
+		monitor.MonitorTraffic())
 }
 
 func launchOpenVPN() *os.Process {

--- a/util/log.go
+++ b/util/log.go
@@ -141,7 +141,8 @@ func (l *Logger) Log(lvl int, fmt string, v ...interface{}) {
 	}
 
 	if lvl == LogFatal {
-		os.Exit(1)
+		// We cannot use os.Exit() not to ignore deferred calls.
+		panic(gofmt.Sprintf(fmt, v...))
 	}
 }
 


### PR DESCRIPTION
There's no portable way to guarantee for child processes to exit when parent process exits. So we need to handle a proper manual cleanup which will guarantee killing all the child processes.

Resolves BV-554.