### PR TITLE
Fix TODOs in dappctrl.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dappctrl.config.local.json
 dappctrl-test.config.local.json
 
 statik/statik.go
+statik/pkgList/packages.txt
 vendor
 
 *.iml

--- a/agent/bill/monitor_test.go
+++ b/agent/bill/monitor_test.go
@@ -271,24 +271,6 @@ func TestNewMonitor(t *testing.T) {
 	}
 }
 
-// TODO(maxim) The test sometimes does not work on CI
-/*func TestMonitorRun(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal(errTestResult)
-		}
-	}()
-
-	mon, err := NewMonitor(time.Second, &reform.DB{}, logger, pr)
-	if err != nil {
-		panic(err)
-	}
-
-	if err := mon.Run(); err == nil {
-		t.Fatal(errTestResult)
-	}
-}*/
-
 func TestMain(m *testing.M) {
 	conf.DB = data.NewDBConfig()
 	conf.Job = job.NewConfig()

--- a/dappctrl-test.config.json
+++ b/dappctrl-test.config.json
@@ -67,6 +67,9 @@
         "ServerConfig": {"A": "A", "B" :"B", "C": "C"},
         "ValidHost": ["privatix.io:443", "127.0.0.1:443"]
     },
+    "EptMsg": {
+        "Timeout": 1
+    },
 
     "Eth": {
         "Contract" : {
@@ -74,7 +77,10 @@
             "PSCAddrHex": ""
         },
         "GethURL": "http://localhost:8545",
-        "TruffleAPIURL": ""
+        "TruffleAPIURL": "",
+        "Timeout": {
+            "ResponseHeaderTimeout": 20
+        }
     },
 
     "JobHandlerTest": {

--- a/dappctrl.config.json
+++ b/dappctrl.config.json
@@ -23,6 +23,9 @@
             "port": "5433"
         }
     },
+    "EptMsg": {
+        "Timeout": 1
+    },
     "Eth": {
         "Contract": {
             "PTCAddrHex": "0x0d825eb81b996c67a55f7da350b6e73bab3cb0ec",
@@ -165,6 +168,12 @@
     },
     "StaticPassword": "",
     "Report": {
-        "ReleaseStage": "alpha"
+        "ReleaseStage": "alpha",
+        "ExcludedPackages": [
+            "github.com/privatix/dappctrl/tool/dappinst",
+            "github.com/privatix/dappctrl/svc/dappvpn",
+            "github.com/privatix/dappctrl/svc/dappvpn/mon",
+            "github.com/privatix/dappctrl/svc/dappvpn/pusher"
+        ]
     }
 }

--- a/data/misc.go
+++ b/data/misc.go
@@ -1,10 +1,10 @@
 package data
 
 import (
-	"encoding/hex"
 	"database/sql"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"strconv"

--- a/messages/ept/service_test.go
+++ b/messages/ept/service_test.go
@@ -28,6 +28,7 @@ var (
 		Log       *util.LogConfig
 		PayServer *pay.Config
 		EptTest   *eptTestConfig
+		EptMsg    *Config
 	}
 
 	testDB *reform.DB
@@ -131,6 +132,7 @@ func TestMain(m *testing.M) {
 	conf.Log = util.NewLogConfig()
 	conf.PayServer = &pay.Config{}
 	conf.EptTest = newEptTestConfig()
+	conf.EptMsg = NewConfig()
 
 	util.ReadTestConfig(&conf)
 
@@ -158,12 +160,12 @@ func TestValidEndpointMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := New(testDB, conf.PayServer.Addr)
+	s, err := New(testDB, conf.PayServer.Addr, conf.EptMsg.Timeout)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	em, err := s.EndpointMessage(fxt.ch.ID, timeout)
+	em, err := s.EndpointMessage(fxt.ch.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,12 +184,12 @@ func TestBadProductConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := New(testDB, conf.PayServer.Addr)
+	s, err := New(testDB, conf.PayServer.Addr, conf.EptMsg.Timeout)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := s.EndpointMessage(fxt.ch.ID, timeout); err == nil {
+	if _, err := s.EndpointMessage(fxt.ch.ID); err == nil {
 		t.Fatal(errValidateMsg)
 	}
 }
@@ -201,12 +203,12 @@ func TestBadProductOfferAccessID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := New(testDB, conf.PayServer.Addr)
+	s, err := New(testDB, conf.PayServer.Addr, conf.EptMsg.Timeout)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := s.EndpointMessage(fxt.ch.ID, timeout); err == nil {
+	if _, err := s.EndpointMessage(fxt.ch.ID); err == nil {
 		t.Fatal(errValidateMsg)
 	}
 }

--- a/monitor/collect_test.go
+++ b/monitor/collect_test.go
@@ -1,0 +1,107 @@
+// +build !nomonitortest
+
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/privatix/dappctrl/data"
+	"github.com/privatix/dappctrl/eth"
+)
+
+func TestMonitorLogCollect(t *testing.T) {
+	defer cleanDB(t)
+
+	mon, _, client := newTestObjects(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ticker := newMockTicker()
+	mon.start(ctx, 5, ticker.C, nil)
+
+	_, agentAddress := insertNewAccount(t, db, agentPass)
+	_, clientAddress := insertNewAccount(t, db, clientPass)
+
+	eventAboutChannel := common.HexToHash(eth.EthDigestChannelCreated)
+	eventAboutOffering := common.HexToHash(eth.EthOfferingCreated)
+	eventAboutToken := common.HexToHash(eth.EthTokenApproval)
+
+	var block uint64 = 10
+
+	dataMap := make(map[string]bool)
+
+	type logToInject struct {
+		event  common.Hash
+		agent  common.Address
+		client common.Address
+	}
+	logsToInject := []logToInject{
+		{eventAboutOffering, someAddress, someAddress}, // 1 match all offerings
+		{someHash, someAddress, someAddress},           // 0 no match
+		{someHash, agentAddress, someAddress},          // 1 match agent
+		{someHash, someAddress, clientAddress},         // 0 match client, but not a client event
+		// ----- 6 confirmations
+		{eventAboutOffering, someAddress, someAddress},  // 1 match all offerings
+		{eventAboutChannel, someAddress, someAddress},   // 0 no match
+		{eventAboutToken, someAddress, someAddress},     // 0 no match
+		{eventAboutChannel, agentAddress, someAddress},  // 1 match agent
+		{eventAboutChannel, someAddress, clientAddress}, // 1 match client
+		// ----- 2 confirmations
+		{eventAboutOffering, agentAddress, someAddress}, // 1 match agent
+		{eventAboutOffering, someAddress, someAddress},  // 1 match all offerings
+		// ----- 0 confirmations
+	}
+	for _, contractAddr := range []common.Address{someAddress, pscAddr} {
+		for _, log := range logsToInject {
+			d := genRandData(32 * 5)
+			dataMap[data.FromBytes(d)] = true
+			var txHash common.Hash
+			copy(txHash[:], genRandData(32))
+			client.injectEvent(&ethtypes.Log{
+				TxHash:      txHash,
+				Address:     contractAddr,
+				BlockNumber: block,
+				Topics: []common.Hash{
+					log.event,
+					log.agent.Hash(),
+					log.client.Hash(),
+				},
+				Data: d,
+			})
+			block++
+		}
+	}
+
+	cases := []struct {
+		confirmations uint64
+		freshnum      uint64
+		lognum        int
+	}{
+		{6, 2, 2}, // freshnum = 2: will skip the first offering event
+		{2, 0, 4}, // freshnum = 0: will include the second offering event
+		{0, 2, 6},
+	}
+
+	var logs []*data.EthLog
+	for _, c := range cases {
+		setUint64Setting(t, db, minConfirmationsKey, c.confirmations)
+		setUint64Setting(t, db, freshOfferingsKey, c.freshnum)
+		ticker.tick()
+		name := fmt.Sprintf("with %d confirmations and %d freshnum",
+			c.confirmations, c.freshnum)
+		logs = expectLogs(t, c.lognum, name, "")
+	}
+
+	for _, e := range logs {
+		if !dataMap[e.Data] {
+			t.Fatal("wrong data saved in a log entry")
+		}
+		delete(dataMap, e.Data)
+	}
+}

--- a/monitor/misc.go
+++ b/monitor/misc.go
@@ -1,7 +1,6 @@
 package monitor
 
 import (
-	"context"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -9,12 +8,4 @@ import (
 
 func mustParseABI(abiJSON string) (abi.ABI, error) {
 	return abi.JSON(strings.NewReader(abiJSON))
-}
-
-func (m *Monitor) errWrapper(ctx context.Context, err error) {
-	select {
-	case <-ctx.Done():
-	default:
-		m.errors <- err
-	}
 }

--- a/monitor/schedule_test.go
+++ b/monitor/schedule_test.go
@@ -1,0 +1,506 @@
+// +build !nomonitortest
+
+package monitor
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"gopkg.in/reform.v1"
+
+	"github.com/privatix/dappctrl/data"
+	"github.com/privatix/dappctrl/eth"
+	"github.com/privatix/dappctrl/util"
+)
+
+var (
+	LogChannelCreated            = "LogChannelCreated"
+	LogChannelTopUp              = "LogChannelToppedUp"
+	LogChannelCloseRequested     = "LogChannelCloseRequested"
+	LogOfferingCreated           = "LogOfferingCreated"
+	LogOfferingDeleted           = "LogOfferingDeleted"
+	LogOfferingPopedUp           = "LogOfferingPopedUp"
+	LogCooperativeChannelClose   = "LogCooperativeChannelClose"
+	LogUnCooperativeChannelClose = "LogUnCooperativeChannelClose"
+)
+
+func TestMonitorSchedule(t *testing.T) {
+	defer cleanDB(t)
+
+	setMaxRetryKey(t)
+
+	mon, queue, _ := newTestObjects(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ticker := newMockTicker()
+	mon.start(ctx, conf.BlockMonitor.Timeout, nil, ticker.C)
+
+	td := generateTestData(t)
+
+	scheduleTest(t, td, queue, ticker, mon)
+}
+
+func toHashes(t *testing.T, topics []interface{}) []common.Hash {
+	hashes := make([]common.Hash, len(topics))
+	if len(topics) > 0 {
+		hashes[0] = common.HexToHash(topics[0].(string))
+	}
+
+	for i, topic := range topics[1:] {
+		switch v := topic.(type) {
+		case string:
+			if bs, err := data.ToBytes(v); err == nil {
+				hashes[i+1] = common.BytesToHash(bs)
+			} else {
+				t.Fatal(err)
+			}
+		case int:
+			hashes[i+1] = common.BigToHash(big.NewInt(int64(v)))
+		case common.Address:
+			hashes[i+1] = v.Hash()
+		case common.Hash:
+			hashes[i+1] = v
+		default:
+			t.Fatalf("unsupported type %T as topic", topic)
+		}
+	}
+
+	return hashes
+}
+
+func pscEvent(t *testing.T, mon *Monitor, customTxHash, logName string,
+	topics, nonIndexedArgs []interface{}) *data.EthLog {
+	ev, ok := mon.pscABI.Events[logName]
+	if !ok {
+		t.Fatal("events with this name do not exist")
+	}
+
+	top := append([]interface{}{}, ev.Id().String())
+	top = append(top, topics...)
+
+	el := insertEvent(t, db, nextBlock(), 0, top...)
+
+	if customTxHash != "" {
+		el.TxHash = customTxHash
+		data.SaveToTestDB(t, db, el)
+	}
+
+	if len(nonIndexedArgs) != 0 {
+		bs, err := ev.Inputs.NonIndexed().Pack(nonIndexedArgs...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		el.Data = data.FromBytes(bs)
+
+		if err := db.Save(el); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return el
+}
+
+func insertEvent(t *testing.T, db *reform.DB, blockNumber uint64,
+	failures uint64, topics ...interface{}) *data.EthLog {
+	el := &data.EthLog{
+		ID:          util.NewUUID(),
+		TxHash:      data.FromBytes(genRandData(32)),
+		TxStatus:    txMinedStatus,
+		BlockNumber: blockNumber,
+		Addr:        data.FromBytes(pscAddr.Bytes()),
+		Data:        data.FromBytes(genRandData(32)),
+		Topics:      toHashes(t, topics),
+		Failures:    failures,
+	}
+	if err := db.Insert(el); err != nil {
+		t.Fatalf("failed to insert a log event into db: %v", err)
+	}
+
+	return el
+}
+
+func setIsAgent(t *testing.T, agent bool) {
+	var val string
+	if agent {
+		val = "true"
+	} else {
+		val = "false"
+	}
+
+	setting := &data.Setting{Key: data.IsAgentKey, Value: val,
+		Name: "user role is agent"}
+	data.SaveToTestDB(t, db, setting)
+}
+
+func agentSchedule(t *testing.T, td *testData, queue *mockQueue,
+	ticker *mockTicker, mon *Monitor) {
+	setIsAgent(t, true)
+
+	// LogChannelCreated good
+	pscEvent(t, mon, txHash, LogChannelCreated, []interface{}{
+		td.addr[0],          // agent
+		someAddress,         // client
+		td.offering[0].Hash, // offering
+	}, nil)
+
+	queue.expect(data.JobAgentAfterChannelCreate, func(j *data.Job) bool {
+		return j.Type == data.JobAgentAfterChannelCreate
+	})
+
+	// LogChannelCreated ignore
+	pscEvent(t, mon, "", LogChannelCreated, []interface{}{
+		someAddress,         // agent
+		td.addr[0],          // client
+		td.offering[0].Hash, // offering
+	}, nil)
+
+	// LogChannelToppedUp good
+	pscEvent(t, mon, "", LogChannelTopUp, []interface{}{
+		td.addr[0],          // agent
+		someAddress,         // client
+		td.offering[0].Hash, // offering
+	}, []interface{}{uint32(td.channel[0].Block), new(big.Int)})
+
+	queue.expect(data.JobAgentAfterChannelTopUp, func(j *data.Job) bool {
+		return j.Type == data.JobAgentAfterChannelTopUp
+	})
+
+	// LogChannelToppedUp ignored
+	// channel does not exist, thus event ignored
+	pscEvent(t, mon, "", LogChannelTopUp, []interface{}{
+		td.addr[0],          // agent
+		td.addr[1],          // client
+		td.offering[1].Hash, // offering
+	}, []interface{}{uint32(td.channel[1].Block), new(big.Int)})
+
+	// LogChannelCloseRequested good
+	pscEvent(t, mon, "", LogChannelCloseRequested,
+		[]interface{}{
+			td.addr[0],          // agent
+			someAddress,         // client
+			td.offering[0].Hash, // offering
+		}, []interface{}{uint32(td.channel[0].Block), new(big.Int)})
+
+	queue.expect(data.JobAgentAfterUncooperativeCloseRequest,
+		func(j *data.Job) bool {
+			return j.Type ==
+				data.JobAgentAfterUncooperativeCloseRequest
+		})
+
+	// LogChannelCloseRequested ignored
+	pscEvent(t, mon, "", LogChannelCloseRequested,
+		[]interface{}{
+			td.addr[0],          // agent
+			someAddress,         // client
+			td.offering[0].Hash, // offering
+		}, []interface{}{uint32(td.channel[1].Block), new(big.Int)})
+
+	// LogOfferingCreated good
+	pscEvent(t, mon, "", LogOfferingCreated, []interface{}{
+		td.addr[0],          // agent
+		td.offering[0].Hash, // offering hash
+		minDepositVal,       // min deposit
+	}, nil)
+
+	queue.expect(data.JobAgentAfterOfferingMsgBCPublish,
+		func(j *data.Job) bool {
+			return j.Type ==
+				data.JobAgentAfterOfferingMsgBCPublish
+		})
+
+	// LogOfferingCreated good
+	pscEvent(t, mon, "", LogOfferingCreated, []interface{}{
+		td.addr[1],          // agent
+		td.offering[1].Hash, // offering
+		minDepositVal,       // min deposit
+	}, nil)
+
+	queue.expect(data.JobAgentAfterOfferingMsgBCPublish,
+		func(j *data.Job) bool {
+			return j.Type ==
+				data.JobAgentAfterOfferingMsgBCPublish
+		})
+
+	// LogOfferingCreated good
+	pscEvent(t, mon, "", LogOfferingCreated, []interface{}{
+		td.addr[1],          // agent
+		td.offering[2].Hash, // offering
+		minDepositVal,       // min deposit
+	}, nil)
+
+	queue.expect(data.JobAgentAfterOfferingMsgBCPublish,
+		func(j *data.Job) bool {
+			return j.Type ==
+				data.JobAgentAfterOfferingMsgBCPublish
+		})
+
+	// LogOfferingDeleted good
+	// TODO(maxim) implementation after afterOfferingDelete job implementation
+
+	// LogOfferingPopedUp good
+	pscEvent(t, mon, "", LogOfferingPopedUp, []interface{}{
+		someAddress,         // agent
+		td.offering[0].Hash, // offering hash
+	}, nil)
+
+	queue.expect(data.JobAgentAfterOfferingMsgBCPublish,
+		func(j *data.Job) bool {
+			return j.Type ==
+				data.JobAgentAfterOfferingMsgBCPublish
+		})
+
+	// LogCooperativeChannelClose good
+	pscEvent(t, mon, "", LogCooperativeChannelClose,
+		[]interface{}{
+			td.addr[0],          // agent
+			someAddress,         // client
+			td.offering[0].Hash, // offering
+		}, []interface{}{uint32(td.channel[0].Block), new(big.Int)})
+
+	queue.expect(data.JobAgentAfterCooperativeClose, func(j *data.Job) bool {
+		return j.Type == data.JobAgentAfterCooperativeClose
+	})
+
+	// LogCooperativeChannelClose ignored
+	pscEvent(t, mon, "", LogCooperativeChannelClose,
+		[]interface{}{
+			td.addr[0],          // agent
+			someAddress,         // client
+			td.offering[0].Hash, // offering
+		}, []interface{}{uint32(td.channel[1].Block), new(big.Int)})
+
+	// LogUnCooperativeChannelClose good
+	pscEvent(t, mon, "", LogUnCooperativeChannelClose,
+		[]interface{}{
+			td.addr[0],          // agent
+			someAddress,         // client
+			td.offering[0].Hash, // offering
+		}, []interface{}{uint32(td.channel[0].Block), new(big.Int)})
+
+	queue.expect(data.JobAgentAfterUncooperativeClose,
+		func(j *data.Job) bool {
+			return j.Type ==
+				data.JobAgentAfterUncooperativeClose
+		})
+
+	// LogUnCooperativeChannelClose ignored
+	pscEvent(t, mon, "", LogUnCooperativeChannelClose,
+		[]interface{}{
+			someAddress,         // agent
+			someAddress,         // client
+			td.offering[0].Hash, // offering
+		}, []interface{}{uint32(td.channel[1].Block), new(big.Int)})
+
+	// Tick here on purpose, so that not all events are ignored because
+	// the offering's been deleted.
+	ticker.tick()
+	queue.awaitCompletion(time.Second)
+}
+
+func clientSchedule(t *testing.T, td *testData, queue *mockQueue,
+	ticker *mockTicker, mon *Monitor) {
+	setIsAgent(t, false)
+
+	// LogChannelCreated good
+	pscEvent(t, mon, txHash, LogChannelCreated, []interface{}{
+		someAddress,         // agent
+		td.addr[1],          // client
+		td.offering[1].Hash, // offering
+	}, nil)
+
+	queue.expect(data.JobClientAfterChannelCreate, func(j *data.Job) bool {
+		return j.Type == data.JobClientAfterChannelCreate
+	})
+
+	// LogChannelCreated ignore
+	pscEvent(t, mon, "", LogChannelCreated, []interface{}{
+		someAddress,         // agent
+		td.addr[0],          // client
+		td.offering[1].Hash, // offering
+	}, nil)
+
+	// LogChannelToppedUp good
+	pscEvent(t, mon, "", LogChannelTopUp, []interface{}{
+		someAddress,         // agent
+		td.addr[1],          // client
+		td.offering[1].Hash, // offering
+	}, []interface{}{uint32(td.channel[1].Block), new(big.Int)})
+
+	queue.expect(data.JobClientAfterChannelTopUp, func(j *data.Job) bool {
+		return j.Type == data.JobClientAfterChannelTopUp
+	})
+
+	// LogChannelToppedUp ignore
+	pscEvent(t, mon, "", LogChannelTopUp, []interface{}{
+		td.addr[1],          // agent
+		td.addr[0],          // client
+		td.offering[1].Hash, // offering
+	}, []interface{}{uint32(td.channel[1].Block), new(big.Int)})
+
+	// LogChannelCloseRequested good
+	pscEvent(t, mon, "", LogChannelCloseRequested,
+		[]interface{}{
+			someAddress,         // agent
+			td.addr[1],          // client
+			td.offering[1].Hash, // offering
+		}, []interface{}{uint32(td.channel[1].Block), new(big.Int)})
+
+	queue.expect(data.JobClientAfterUncooperativeCloseRequest,
+		func(j *data.Job) bool {
+			return j.Type ==
+				data.JobClientAfterUncooperativeCloseRequest
+		})
+
+	// LogChannelCloseRequested ignored
+	pscEvent(t, mon, "", LogChannelCloseRequested,
+		[]interface{}{
+			someAddress,         // agent
+			td.addr[0],          // client
+			td.offering[1].Hash, // offering
+		}, []interface{}{uint32(td.channel[1].Block), new(big.Int)})
+
+	// LogOfferingCreated good
+	pscEvent(t, mon, "", LogOfferingCreated, []interface{}{
+		td.addr[0],          // agent
+		td.offering[1].Hash, // offering
+		minDepositVal,       // min deposit
+	}, nil)
+
+	queue.expect(data.JobClientAfterOfferingMsgBCPublish,
+		func(j *data.Job) bool {
+			return j.Type ==
+				data.JobClientAfterOfferingMsgBCPublish
+		})
+
+	// LogOfferingCreated good
+	pscEvent(t, mon, "", LogOfferingCreated, []interface{}{
+		td.addr[1],          // agent
+		td.offering[1].Hash, // offering
+		minDepositVal,       // min deposit
+	}, nil)
+
+	queue.expect(data.JobClientAfterOfferingMsgBCPublish,
+		func(j *data.Job) bool {
+			return j.Type ==
+				data.JobClientAfterOfferingMsgBCPublish
+		})
+
+	// LogOfferingCreated good
+	pscEvent(t, mon, "", LogOfferingCreated, []interface{}{
+		td.addr[1],          // agent
+		td.offering[2].Hash, // offering
+		minDepositVal,       // min deposit
+	}, nil)
+
+	queue.expect(data.JobClientAfterOfferingMsgBCPublish,
+		func(j *data.Job) bool {
+			return j.Type ==
+				data.JobClientAfterOfferingMsgBCPublish
+		})
+
+	// LogOfferingDeleted good
+	// TODO(maxim) implementation after afterOfferingDelete job implementation
+
+	// LogOfferingPopedUp good
+	pscEvent(t, mon, "", LogOfferingPopedUp, []interface{}{
+		someAddress,         // agent
+		td.offering[2].Hash, // offering hash
+	}, nil)
+
+	queue.expect(data.JobClientAfterOfferingPopUp,
+		func(j *data.Job) bool {
+			return j.Type ==
+				data.JobClientAfterOfferingPopUp
+		})
+
+	// LogCooperativeChannelClose good
+	pscEvent(t, mon, "", LogCooperativeChannelClose,
+		[]interface{}{
+			someAddress,         // agent
+			td.addr[1],          // client
+			td.offering[1].Hash, // offering
+		}, []interface{}{uint32(td.channel[1].Block), new(big.Int)})
+
+	queue.expect(data.JobClientAfterCooperativeClose, func(j *data.Job) bool {
+		return j.Type == data.JobClientAfterCooperativeClose
+	})
+
+	// LogCooperativeChannelClose ignored
+	pscEvent(t, mon, "", LogCooperativeChannelClose,
+		[]interface{}{
+			someAddress,         // agent
+			td.addr[0],          // client
+			td.offering[1].Hash, // offering
+		}, []interface{}{uint32(td.channel[0].Block), new(big.Int)})
+
+	// LogUnCooperativeChannelClose good
+	pscEvent(t, mon, "", LogUnCooperativeChannelClose,
+		[]interface{}{
+			someAddress,         // agent
+			td.addr[1],          // client
+			td.offering[1].Hash, // offering
+		}, []interface{}{uint32(td.channel[1].Block), new(big.Int)})
+
+	queue.expect(data.JobClientAfterUncooperativeClose,
+		func(j *data.Job) bool {
+			return j.Type ==
+				data.JobClientAfterUncooperativeClose
+		})
+
+	// LogUnCooperativeChannelClose ignored
+	pscEvent(t, mon, "", LogUnCooperativeChannelClose,
+		[]interface{}{
+			someAddress,         // agent
+			td.addr[1],          // client
+			td.offering[1].Hash, // offering
+		}, []interface{}{uint32(td.channel[0].Block), new(big.Int)})
+
+	// Tick here on purpose, so that not all events are ignored because
+	// the offering's been deleted.
+	ticker.tick()
+	queue.awaitCompletion(time.Second)
+}
+
+func commonSchedule(t *testing.T, td *testData, queue *mockQueue,
+	ticker *mockTicker, agent bool) {
+	setIsAgent(t, agent)
+
+	insertEvent(t, db, nextBlock(), 0, eth.EthTokenApproval,
+		td.addr[0], pscAddr, 123)
+
+	queue.expect(data.JobPreAccountAddBalance, func(j *data.Job) bool {
+		return j.Type == data.JobPreAccountAddBalance
+	})
+
+	insertEvent(t, db, nextBlock(), 0, eth.EthTokenTransfer,
+		td.addr[0], someAddress, 123)
+
+	queue.expect(data.JobAfterAccountAddBalance, func(j *data.Job) bool {
+		return j.Type == data.JobAfterAccountAddBalance
+	})
+
+	insertEvent(t, db, nextBlock(), 0, eth.EthTokenTransfer,
+		someAddress, td.addr[0], 123)
+
+	queue.expect(data.JobAfterAccountAddBalance, func(j *data.Job) bool {
+		return j.Type == data.JobAfterAccountAddBalance
+	})
+
+	// Tick here on purpose, so that not all events are ignored because
+	// the offering's been deleted.
+	ticker.tick()
+	queue.awaitCompletion(time.Second)
+}
+
+func scheduleTest(t *testing.T, td *testData, queue *mockQueue,
+	ticker *mockTicker, mon *Monitor) {
+	commonSchedule(t, td, queue, ticker, true)
+	commonSchedule(t, td, queue, ticker, false)
+	agentSchedule(t, td, queue, ticker, mon)
+	clientSchedule(t, td, queue, ticker, mon)
+}

--- a/pay/misc.go
+++ b/pay/misc.go
@@ -13,20 +13,20 @@ import (
 
 // Codes for unauthorized replies.
 const (
-	errCodeNoChannel = 1
+	errCodeNoChannel     = 1
 	errCodeClosedChannel = iota
 )
 
 // Codes for bad request replies.
 const (
 	errCodeNonParsablePayload = 1
-	errCodeInvalidBalance = iota
-	errCodeInvalidSignature = iota
+	errCodeInvalidBalance     = iota
+	errCodeInvalidSignature   = iota
 )
 
 var errUnexpected = &srv.Error{
-	Status: http.StatusBadRequest,
-	Code: errCodeInvalidSignature,
+	Status:  http.StatusBadRequest,
+	Code:    errCodeInvalidSignature,
 	Message: "Client signature does not match",
 }
 
@@ -41,9 +41,9 @@ func (s *Server) findChannel(w http.ResponseWriter, offeringHash string,
 	err := s.db.SelectOneTo(channel, tail, offeringHash, agentAddr, block)
 	if err != nil {
 		s.RespondError(w, &srv.Error{
-			Status: http.StatusUnauthorized,
+			Status:  http.StatusUnauthorized,
 			Message: "Channel is not found",
-			Code: errCodeNoChannel,
+			Code:    errCodeNoChannel,
 		})
 		return nil, false
 	}
@@ -55,9 +55,9 @@ func (s *Server) validateChannelState(w http.ResponseWriter,
 	ch *data.Channel) bool {
 	if ch.ChannelStatus != data.ChannelActive {
 		s.RespondError(w, &srv.Error{
-			Status: http.StatusUnauthorized,
+			Status:  http.StatusUnauthorized,
 			Message: "Channel is closed",
-			Code: errCodeClosedChannel,
+			Code:    errCodeClosedChannel,
 		})
 		return false
 	}
@@ -115,8 +115,8 @@ func (s *Server) verifySignature(w http.ResponseWriter,
 
 	if !crypto.VerifySignature(pub, hash, sig[:len(sig)-1]) {
 		s.RespondError(w, &srv.Error{
-			Status: http.StatusBadRequest,
-			Code: errCodeInvalidSignature,
+			Status:  http.StatusBadRequest,
+			Code:    errCodeInvalidSignature,
 			Message: "Client signature does not match",
 		})
 		return false
@@ -151,8 +151,8 @@ func (s *Server) updateChannelWithPayment(w http.ResponseWriter,
 	}
 	if affected == 0 {
 		s.RespondError(w, &srv.Error{
-			Status: http.StatusBadRequest,
-			Code: errCodeInvalidBalance,
+			Status:  http.StatusBadRequest,
+			Code:    errCodeInvalidBalance,
 			Message: "Invalid balance amount",
 		})
 		return false

--- a/pay/pay_test.go
+++ b/pay/pay_test.go
@@ -24,10 +24,10 @@ import (
 var (
 	testServer *Server
 	testDB     *reform.DB
-	conf struct {
-		DB  *data.DBConfig
-		Log *util.LogConfig
-		PayServer *Config
+	conf       struct {
+		DB            *data.DBConfig
+		Log           *util.LogConfig
+		PayServer     *Config
 		PayServerTest struct {
 			ServerStartupDelay uint // In milliseconds.
 		}
@@ -181,7 +181,7 @@ func TestMain(m *testing.M) {
 	defer data.CloseDB(testDB)
 	testServer = NewServer(conf.PayServer, logger, testDB)
 	go func() {
-		err := testServer.ListenAndServe();
+		err := testServer.ListenAndServe()
 		if err != http.ErrServerClosed {
 			log.Fatalf("failed to serve session requests: %s", err)
 		}

--- a/pay/server.go
+++ b/pay/server.go
@@ -25,7 +25,7 @@ func NewConfig() *Config {
 type Server struct {
 	*srv.Server
 
-	db     *reform.DB
+	db *reform.DB
 }
 
 const payPath = "/v1/pmtChannel/pay"
@@ -34,7 +34,7 @@ const payPath = "/v1/pmtChannel/pay"
 func NewServer(conf *Config, logger *util.Logger, db *reform.DB) *Server {
 	s := &Server{
 		Server: srv.NewServer(conf.Config, logger),
-		db:  db,
+		db:     db,
 	}
 
 	s.HandleFunc(payPath, s.RequireHTTPMethods(s.handlePay, http.MethodPost))

--- a/proc/handlers/job.go
+++ b/proc/handlers/job.go
@@ -8,7 +8,6 @@ import (
 
 // HandlersMap returns handlers map needed to construct job queue.
 func HandlersMap(worker *worker.Worker) job.HandlerMap {
-	// TODO: add clients
 	return job.HandlerMap{
 		// Agent jobs.
 		data.JobAgentAfterChannelCreate:             worker.AgentAfterChannelCreate,

--- a/proc/worker/adapter.go
+++ b/proc/worker/adapter.go
@@ -172,9 +172,7 @@ func (b *ethBackendInstance) PSCGetChannelInfo(opts *bind.CallOpts,
 func (b *ethBackendInstance) PSCCreateChannel(opts *bind.TransactOpts,
 	agent common.Address, hash [common.HashLength]byte,
 	deposit *big.Int) (*types.Transaction, error) {
-	// TODO: Remove authHash.
-	authHash := [common.HashLength]byte{}
-	tx, err := b.psc.CreateChannel(opts, agent, hash, deposit, authHash)
+	tx, err := b.psc.CreateChannel(opts, agent, hash, deposit, common.Hash{})
 	if err != nil {
 		err = fmt.Errorf("failed to create PSC channel: %s", err)
 	}

--- a/proc/worker/agent.go
+++ b/proc/worker/agent.go
@@ -293,8 +293,7 @@ func (w *Worker) AgentPreEndpointMsgCreate(job *data.Job) error {
 		return err
 	}
 
-	// TODO: move timeout to conf.
-	msg, err := w.ept.EndpointMessage(channel.ID, time.Second)
+	msg, err := w.ept.EndpointMessage(channel.ID)
 	if err != nil {
 		return fmt.Errorf("could not make endpoint message: %v", err)
 	}

--- a/proc/worker/client.go
+++ b/proc/worker/client.go
@@ -825,7 +825,6 @@ func (w *Worker) ClientAfterOfferingPopUp(job *data.Job) error {
 	return w.db.Update(&offering)
 }
 
-
 func (w *Worker) clientRetrieveAndSaveOfferingFromSOMC(
 	job *data.Job, block uint64, agentAddr common.Address, hash common.Hash) error {
 	offeringsData, err := w.somc.FindOfferings([]string{

--- a/proc/worker/eth.go
+++ b/proc/worker/eth.go
@@ -10,8 +10,10 @@ import (
 )
 
 func (w *Worker) getTransaction(hash common.Hash) (*types.Transaction, error) {
-	// TODO: move timeout to conf
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, cancel := context.WithTimeout(context.Background(),
+		time.Duration(
+			w.ethConfig.Timeout.ResponseHeaderTimeout)*
+			time.Second)
 	defer cancel()
 
 	ethTx, pen, err := w.ethBack.GetTransactionByHash(ctx, hash)
@@ -20,7 +22,8 @@ func (w *Worker) getTransaction(hash common.Hash) (*types.Transaction, error) {
 	}
 
 	if pen {
-		return nil, fmt.Errorf("unexpected pending state of transaction")
+		return nil, fmt.Errorf("unexpected pending state" +
+			" of transaction")
 	}
 
 	return ethTx, nil

--- a/proc/worker/misc.go
+++ b/proc/worker/misc.go
@@ -146,13 +146,15 @@ func parseJobData(job *data.Job, data interface{}) error {
 }
 
 func (w *Worker) ethBalance(addr common.Address) (*big.Int, error) {
-	// TODO: move timeout to conf
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, cancel := context.WithTimeout(context.Background(),
+		time.Duration(w.ethConfig.Timeout.ResponseHeaderTimeout)*
+			time.Second)
 	defer cancel()
 
 	amount, err := w.ethBack.EthBalanceAt(ctx, addr)
 	if err != nil {
-		return nil, fmt.Errorf("could not get eth balance: %v", err)
+		return nil, fmt.Errorf("could not get eth"+
+			" balance: %v", err)
 	}
 
 	return amount, nil

--- a/proc/worker/worker.go
+++ b/proc/worker/worker.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
-	reform "gopkg.in/reform.v1"
+	"gopkg.in/reform.v1"
 
 	"github.com/privatix/dappctrl/client/svcrun"
 	"github.com/privatix/dappctrl/data"
+	"github.com/privatix/dappctrl/eth"
 	"github.com/privatix/dappctrl/eth/contract"
 	"github.com/privatix/dappctrl/job"
 	"github.com/privatix/dappctrl/messages/ept"
@@ -61,6 +62,7 @@ type Worker struct {
 	deployConfig   deployConfigFunc
 	processor      *proc.Processor
 	runner         svcrun.ServiceRunner
+	ethConfig      *eth.Config
 }
 
 // NewWorker returns new instance of worker.
@@ -68,13 +70,15 @@ func NewWorker(logger *util.Logger, db *reform.DB, somc *somc.Conn,
 	ethBack EthBackend, gasConc *GasConf, pscAddr common.Address,
 	payAddr string, pwdGetter data.PWDGetter,
 	decryptKeyFunc data.ToPrivateKeyFunc,
-	clientVPN *config.Config) (*Worker, error) {
-	abi, err := abi.JSON(strings.NewReader(contract.PrivatixServiceContractABI))
+	clientVPN *config.Config, eptConf *ept.Config,
+	ethConf *eth.Config) (*Worker, error) {
+	abi, err := abi.JSON(
+		strings.NewReader(contract.PrivatixServiceContractABI))
 	if err != nil {
 		return nil, err
 	}
 
-	eptService, err := ept.New(db, payAddr)
+	eptService, err := ept.New(db, payAddr, eptConf.Timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -86,6 +90,7 @@ func NewWorker(logger *util.Logger, db *reform.DB, somc *somc.Conn,
 		decryptKeyFunc: decryptKeyFunc,
 		gasConf:        gasConc,
 		ept:            eptService,
+		ethConfig:      ethConf,
 		ethBack:        ethBack,
 		pscAddr:        pscAddr,
 		pwdGetter:      pwdGetter,

--- a/proc/worker/worker_test.go
+++ b/proc/worker/worker_test.go
@@ -16,8 +16,10 @@ import (
 	"gopkg.in/reform.v1"
 
 	"github.com/privatix/dappctrl/data"
+	"github.com/privatix/dappctrl/eth"
 	"github.com/privatix/dappctrl/job"
 	"github.com/privatix/dappctrl/messages"
+	"github.com/privatix/dappctrl/messages/ept"
 	"github.com/privatix/dappctrl/messages/ept/config"
 	"github.com/privatix/dappctrl/messages/offer"
 	"github.com/privatix/dappctrl/pay"
@@ -34,6 +36,8 @@ type testConfig struct {
 		ReactionDelay time.Duration // In milliseconds.
 	}
 	Gas       *GasConf
+	EptMsg    *ept.Config
+	Eth       *eth.Config
 	Job       *job.Config
 	Log       *util.LogConfig
 	PayServer *pay.Config
@@ -46,6 +50,8 @@ func newTestConfig() *testConfig {
 	return &testConfig{
 		clientVPN: config.NewConfig(),
 		DB:        data.NewDBConfig(),
+		EptMsg:    ept.NewConfig(),
+		Eth:       eth.NewConfig(),
 		Job:       job.NewConfig(),
 		Log:       util.NewLogConfig(),
 		SOMC:      somc.NewConfig(),
@@ -88,7 +94,7 @@ func newWorkerTest(t *testing.T) *workerTest {
 
 	worker, err := NewWorker(logger, db, somcConn, ethBack, conf.Gas,
 		conf.pscAddr, conf.PayServer.Addr, pwdStorage,
-		data.TestToPrivateKey, conf.clientVPN)
+		data.TestToPrivateKey, conf.clientVPN, conf.EptMsg, conf.Eth)
 	if err != nil {
 		somcConn.Close()
 		fakeSOMC.Close()

--- a/report/bugsnag/util.go
+++ b/report/bugsnag/util.go
@@ -1,0 +1,46 @@
+package bugsnag
+
+import (
+	"bufio"
+	"bytes"
+
+	"github.com/privatix/dappctrl/statik"
+)
+
+const (
+	pkgFile = "/pkgList/packages.txt"
+	mainPkg = "github.com/privatix/dappctrl/main*"
+)
+
+func pkgList(excluded map[string]bool) (result []string, err error) {
+	data, err := statik.ReadFile(pkgFile)
+	if err != nil {
+		return
+	}
+
+	r := bytes.NewReader(data)
+
+	scanner := bufio.NewScanner(r)
+
+	var pkgs []string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if excluded[line] {
+			continue
+		}
+
+		pkgs = append(pkgs, line+"*")
+
+	}
+
+	if err = scanner.Err(); err != nil {
+		return
+	}
+
+	result = append(result, mainPkg)
+
+	// all except the parent package
+	result = append(result, pkgs[1:]...)
+	return
+}

--- a/sesssrv/product.go
+++ b/sesssrv/product.go
@@ -71,9 +71,7 @@ func serviceEndpointAddress(config map[string]string,
 
 	if extIP, ok := config[externalIP]; ok {
 		ip := net.ParseIP(extIP)
-
-		// TODO(maxim) IPv4 only
-		if ip.To4() != nil {
+		if ip != nil {
 			return &extIP
 		}
 		return product.ServiceEndpointAddress

--- a/statik/misc.go
+++ b/statik/misc.go
@@ -7,6 +7,8 @@ import (
 	"github.com/rakyll/statik/fs"
 )
 
+//go:generate chmod +x ./pkgList/gen.sh
+//go:generate ./pkgList/gen.sh
 //go:generate rm -f statik.go
 //go:generate statik -f -src=. -dest=..
 
@@ -22,7 +24,7 @@ func ReadFile(name string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to open statik FS: %s", err)
 	}
 
-	file, err := fs.Open(EndpointJSONSchema)
+	file, err := fs.Open(name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open statik file: %s", err)
 	}

--- a/statik/pkgList/gen.sh
+++ b/statik/pkgList/gen.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+go list ../... > ./pkgList/packages.txt

--- a/uisrv/account_test.go
+++ b/uisrv/account_test.go
@@ -255,7 +255,7 @@ func TestAccountCreateUpdateBalancesJob(t *testing.T) {
 
 	err := testServer.db.SelectOneTo(&data.Job{},
 		`WHERE related_id=$1 AND related_type=$2 AND type=$3`,
-		acc.ID, data.JobAccount, data.JobAccountUpdateBalances);
+		acc.ID, data.JobAccount, data.JobAccountUpdateBalances)
 	if err != nil {
 		t.Fatal("update balances job expected, got error: ", err)
 	}

--- a/uisrv/channel_test.go
+++ b/uisrv/channel_test.go
@@ -70,6 +70,7 @@ func testJob(t *testing.T, ch *data.Channel) {
 	job := data.NewTestJob(data.JobClientPreChannelCreate,
 		data.JobUser, data.JobOffering)
 	job.RelatedID = ch.ID
+	job.Status = data.JobDone
 	insertItems(t, job)
 }
 
@@ -244,8 +245,7 @@ func checkRespGetCliChan(t *testing.T, chID string) {
 
 }
 
-// TODO(maxim) fix text. It ceased to function after BV-431
-/*func TestGetChannels(t *testing.T) {
+func TestGetChannels(t *testing.T) {
 	defer cleanDB(t)
 	setTestUserCredentials(t)
 
@@ -285,7 +285,7 @@ func checkRespGetCliChan(t *testing.T, chID string) {
 
 	// check response body
 	checkRespGetCliChan(t, chClient.ID)
-}*/
+}
 
 func getChannelStatus(t *testing.T, id string, agent bool) *http.Response {
 	var path string

--- a/uisrv/offering.go
+++ b/uisrv/offering.go
@@ -277,7 +277,7 @@ func (s *Server) handlePutClientOfferingStatus(
 	if err := s.queue.Add(&data.Job{
 		Type:        data.JobClientPreChannelCreate,
 		RelatedType: data.JobChannel,
-		RelatedID:   util.NewUUID(),
+		RelatedID:   id,
 		CreatedBy:   data.JobUser,
 		Data:        dataJSON,
 	}); err != nil {

--- a/uisrv/offering_test.go
+++ b/uisrv/offering_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/privatix/dappctrl/data"
+	"github.com/privatix/dappctrl/proc/worker"
 	"github.com/privatix/dappctrl/util"
 )
 
@@ -356,8 +357,7 @@ func TestPutOfferingStatus(t *testing.T) {
 	data.DeleteFromTestDB(t, testServer.db, jobPublish)
 }
 
-// TODO(maxim) fix text. It ceased to function after BV-430
-/*func TestPutClientOfferingStatus(t *testing.T) {
+func TestPutClientOfferingStatus(t *testing.T) {
 	defer cleanDB(t)
 
 	setTestUserCredentials(t)
@@ -403,7 +403,7 @@ func TestPutOfferingStatus(t *testing.T) {
 	}
 
 	data.DeleteFromTestDB(t, testServer.db, job)
-}*/
+}
 
 func TestGetOfferingStatus(t *testing.T) {
 	defer cleanDB(t)


### PR DESCRIPTION
Resolves BV-530.

Changes:

* monitor_test.go - removed TestMonitorRun test. The test sometimes does not work on CI.

* EptMsg timeout from config.

* Blockchain monitor timeout from config.

* Blockchain monitor fixed memory leak.

* Blockchain monitor schedule tests refactor.

* Worker timeout from Eth config.

* List of packages is generated dynamically for bugsnag.

* Ignore packages list for bugsnag from config.

* Fixed TestGetChannels from uisrv.

* Fixed handlePutClientOfferingStatus & TestPutClientOfferingStatus from uisrv.