### PR TITLE
uncoop close req triggering and some refactoring

### DIFF
--- a/data/schema.go
+++ b/data/schema.go
@@ -309,7 +309,6 @@ const (
 	JobAgentAfterChannelTopUp               = "agentAfterChannelTopUp"
 	JobAgentAfterUncooperativeCloseRequest  = "agentAfterUncooperativeCloseRequest"
 	JobAgentAfterUncooperativeClose         = "agentAfterUncooperativeClose"
-	JobAgentPreCooperativeClose             = "agentPreCooperativeClose"
 	JobAgentAfterCooperativeClose           = "agentAfterCooperativeClose"
 	JobAgentPreServiceSuspend               = "agentPreServiceSuspend"
 	JobAgentPreServiceUnsuspend             = "agentPreServiceUnsuspend"

--- a/data/schema.go
+++ b/data/schema.go
@@ -207,7 +207,8 @@ type Contract struct {
 
 // Setting keys.
 const (
-	IsAgentKey = "user.isagent" // specifies user role. "true" - agent. "false" - client.
+	IsAgentKey         = "user.isagent" // specifies user role. "true" - agent. "false" - client.
+	DefaultGasPriceKey = "eth.default.gasprice"
 )
 
 // Permissions for settings.

--- a/proc/worker/agent.go
+++ b/proc/worker/agent.go
@@ -102,10 +102,10 @@ func (w *Worker) AgentAfterUncooperativeCloseRequest(job *data.Job) error {
 	}
 
 	if channel.ServiceStatus != data.ServiceTerminated {
-		if err = w.addJob(data.JobAgentPreServiceTerminate,
-			data.JobChannel, channel.ID); err != nil {
-			return fmt.Errorf("could not add %s job: %v",
-				data.JobAgentPreServiceTerminate, err)
+		_, err = w.processor.TerminateChannel(
+			channel.ID, data.JobTask, true)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -126,8 +126,9 @@ func (w *Worker) AgentAfterUncooperativeClose(job *data.Job) error {
 	}
 
 	if channel.ServiceStatus != data.ServiceTerminated {
-		if err = w.addJob(data.JobAgentPreServiceTerminate,
-			data.JobChannel, channel.ID); err != nil {
+		_, err = w.processor.TerminateChannel(
+			channel.ID, data.JobTask, true)
+		if err != nil {
 			return err
 		}
 	}

--- a/proc/worker/agent.go
+++ b/proc/worker/agent.go
@@ -101,17 +101,11 @@ func (w *Worker) AgentAfterUncooperativeCloseRequest(job *data.Job) error {
 		return err
 	}
 
-	var jobToCreate string
-
-	if channel.ReceiptBalance > 0 {
-		jobToCreate = data.JobAgentPreCooperativeClose
-	} else if channel.ServiceStatus != data.ServiceTerminated {
-		jobToCreate = data.JobAgentPreServiceTerminate
-	}
-
-	if jobToCreate != "" {
-		if err = w.addJob(jobToCreate, data.JobChannel, channel.ID); err != nil {
-			return fmt.Errorf("could not add %s job: %v", jobToCreate, err)
+	if channel.ServiceStatus != data.ServiceTerminated {
+		if err = w.addJob(data.JobAgentPreServiceTerminate,
+			data.JobChannel, channel.ID); err != nil {
+			return fmt.Errorf("could not add %s job: %v",
+				data.JobAgentPreServiceTerminate, err)
 		}
 	}
 
@@ -188,7 +182,7 @@ func (w *Worker) AgentPreServiceUnsuspend(job *data.Job) error {
 	return err
 }
 
-// AgentPreServiceTerminate marks service as active.
+// AgentPreServiceTerminate terminates the service.
 func (w *Worker) AgentPreServiceTerminate(job *data.Job) error {
 	channel, err := w.agentUpdateServiceStatus(job,
 		data.JobAgentPreServiceTerminate)

--- a/uisrv/channel.go
+++ b/uisrv/channel.go
@@ -23,7 +23,7 @@ const (
 var (
 	channelsGetParams = []queryParam{
 		{Name: "id", Field: "id"},
-		{Name: "channfelStatus", Field: "channel_status"},
+		{Name: "channelStatus", Field: "channel_status"},
 		{Name: "serviceStatus", Field: "service_status"},
 	}
 

--- a/uisrv/db.go
+++ b/uisrv/db.go
@@ -13,6 +13,7 @@ func (s *Server) findTo(w http.ResponseWriter, v reform.Record, id string) bool 
 			s.replyNotFound(w)
 			return false
 		}
+		s.logger.Error("failed to find %T: %v", v, err)
 		s.replyUnexpectedErr(w)
 		return false
 	}
@@ -20,15 +21,17 @@ func (s *Server) findTo(w http.ResponseWriter, v reform.Record, id string) bool 
 }
 
 func (s *Server) selectOneTo(w http.ResponseWriter, v reform.Record,
-	filter string, args ...interface{}) (err error) {
-	if err = s.db.SelectOneTo(v, filter, args...); err != nil {
+	filter string, args ...interface{}) bool {
+	if err := s.db.SelectOneTo(v, filter, args...); err != nil {
 		if err == sql.ErrNoRows {
 			s.replyNotFound(w)
-			return
+			return false
 		}
+		s.logger.Error("failed to find %T: %v", v, err)
 		s.replyUnexpectedErr(w)
+		return false
 	}
-	return
+	return true
 }
 
 func (s *Server) insert(w http.ResponseWriter, rec reform.Struct) bool {

--- a/uisrv/offering.go
+++ b/uisrv/offering.go
@@ -266,8 +266,7 @@ func (s *Server) handlePutClientOfferingStatus(
 	offer := new(data.Offering)
 	acc := new(data.Account)
 
-	if err := s.selectOneTo(w, offer,
-		"WHERE "+clientGetOfferFilterByID, id); err != nil {
+	if !s.selectOneTo(w, offer, "WHERE "+clientGetOfferFilterByID, id) {
 		return
 	}
 	if !s.findTo(w, acc, req.Account) {


### PR DESCRIPTION
* client now can trigger uncooperative close request.
* uisrv uses `proc` package for service status changes.
* agent jobs use `proc` package for service termination.
* removed not used `agentPreCooperativeClose`. Cooperative close happens at service termination.