### PR TITLE
client uncoop close tuning

### DIFF
--- a/dappctrl-dev.config.json
+++ b/dappctrl-dev.config.json
@@ -85,6 +85,11 @@
         "TryLimit": 3,
         "TryPeriod": 60000,
         "Types": {
+            "clientPreUncooperativeClose": {
+                "TryLimit": 200,
+                "TryPeriod": 180000,
+                "FirstStartDelay": 7500000
+            },
             "clientPreChannelCreate": {
                 "Duplicated": true,
                 "TryLimit": 3,

--- a/dappctrl.config.json
+++ b/dappctrl.config.json
@@ -86,6 +86,11 @@
         "TryLimit": 3,
         "TryPeriod": 60000,
         "Types": {
+            "clientPreUncooperativeClose": {
+                "TryLimit": 200,
+                "TryPeriod": 180000,
+                "FirstStartDelay": 7500000
+            },
             "clientPreChannelCreate": {
                 "Duplicated": true,
                 "TryLimit": 3,

--- a/proc/worker/client.go
+++ b/proc/worker/client.go
@@ -56,7 +56,8 @@ func (w *Worker) clientValidateChannelForClose(
 	}
 
 	// check service status
-	if ch.ServiceStatus == data.ServiceTerminated {
+	if ch.ServiceStatus != data.ServiceTerminated &&
+		ch.ServiceStatus != data.ServicePending {
 		return ErrInvalidServiceStatus
 	}
 
@@ -437,14 +438,6 @@ func (w *Worker) ClientAfterUncooperativeClose(job *data.Job) error {
 	ch.ChannelStatus = data.ChannelClosedUncoop
 	if err := w.saveRecord(logger, ch); err != nil {
 		return err
-	}
-
-	if ch.ServiceStatus != data.ServiceTerminated {
-		_, err = w.processor.TerminateChannel(ch.ID, data.JobTask, false)
-		if err != nil {
-			logger.Error(err.Error())
-			return ErrTerminateChannel
-		}
 	}
 
 	agent, err := w.account(logger, ch.Agent)


### PR DESCRIPTION
Client uncooperative close now requires service to be either in pending or terminated state.