### PR TITLE
Support subscriptions for object state changes.

### DIFF
--- a/job/queue.go
+++ b/job/queue.go
@@ -71,8 +71,8 @@ type Queue interface {
 	Add(j *data.Job) error
 	Process() error
 	Close()
-	Subscribe(relatedID, subID string, subFunc SubFunc) error
-	Unsubscribe(relatedID, subID string) error
+	Subscribe(relatedIDs []string, subID string, subFunc SubFunc) error
+	Unsubscribe(relatedIDs []string, subID string) error
 }
 
 type queue struct {
@@ -446,11 +446,7 @@ func AddWithDelay(q Queue, jobType, relatedType, relatedID, creator string,
 // SubFunc is a job result notification callback.
 type SubFunc func(job *data.Job, result error)
 
-// Subscribe adds a subscription to job result notifications.
-func (q *queue) Subscribe(relatedID, subID string, subFunc SubFunc) error {
-	q.subsMtx.Lock()
-	defer q.subsMtx.Unlock()
-
+func (q *queue) subscribe(relatedID, subID string, subFunc SubFunc) error {
 	if subs, ok := q.subs[relatedID]; ok {
 		for _, v := range subs {
 			if v.subID == subID {
@@ -464,11 +460,27 @@ func (q *queue) Subscribe(relatedID, subID string, subFunc SubFunc) error {
 	return nil
 }
 
-// Subscribe adds a subscription to job result notifications.
-func (q *queue) Unsubscribe(relatedID, subID string) error {
+// Subscribe adds a subscription to job result notifications for given ids of
+// related objects. SubID is used to distinguish between different
+// subscriptions to a same related object.
+func (q *queue) Subscribe(
+	relatedIDs []string, subID string, subFunc SubFunc) error {
 	q.subsMtx.Lock()
 	defer q.subsMtx.Unlock()
 
+	for i, v := range relatedIDs {
+		if err := q.subscribe(v, subID, subFunc); err != nil {
+			for j := 0; j < i; j++ {
+				q.unsubscribe(relatedIDs[j], subID)
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (q *queue) unsubscribe(relatedID, subID string) error {
 	if subs, ok := q.subs[relatedID]; ok {
 		for i, v := range subs {
 			if v.subID != subID {
@@ -487,4 +499,21 @@ func (q *queue) Unsubscribe(relatedID, subID string) error {
 	}
 
 	return ErrSubscriptionNotFound
+}
+
+// Unsubscribe removes a subscription from job result notifications for given
+// ids of related objects. SubID is used to distinguish between different
+// subscriptions to a same related object.
+func (q *queue) Unsubscribe(relatedIDs []string, subID string) error {
+	q.subsMtx.Lock()
+	defer q.subsMtx.Unlock()
+
+	var err error
+	for _, v := range relatedIDs {
+		if err2 := q.unsubscribe(v, subID); err == nil {
+			err = err2
+		}
+	}
+
+	return err
 }

--- a/job/queue_test.go
+++ b/job/queue_test.go
@@ -243,9 +243,9 @@ func TestSubscribe(t *testing.T) {
 
 	util.TestExpectResult(t, "Add job", nil, q.Add(&job1))
 	util.TestExpectResult(t, "Subscribe", nil,
-		q.Subscribe(job1.RelatedID, "1234", subf))
+		q.Subscribe([]string{job1.RelatedID}, "1234", subf))
 	util.TestExpectResult(t, "Subscribe", ErrSubscriptionExists,
-		q.Subscribe(job1.RelatedID, "1234", subf))
+		q.Subscribe([]string{job1.RelatedID}, "1234", subf))
 
 	if params := <-subch; params.job.ID != job1.ID ||
 		params.result == nil || params.result.Error() != "some error" {
@@ -259,9 +259,9 @@ func TestSubscribe(t *testing.T) {
 	}
 
 	util.TestExpectResult(t, "Unsubscribe", nil,
-		q.Unsubscribe(job1.RelatedID, "1234"))
+		q.Unsubscribe([]string{job1.RelatedID}, "1234"))
 	util.TestExpectResult(t, "Unsubscribe", ErrSubscriptionNotFound,
-		q.Unsubscribe(job1.RelatedID, "1234"))
+		q.Unsubscribe([]string{job1.RelatedID}, "1234"))
 }
 
 func TestMain(m *testing.M) {

--- a/job/test.go
+++ b/job/test.go
@@ -17,31 +17,32 @@ const (
 
 // QueueMock is a queue method handler.
 type QueueMock func(method int, job *data.Job,
-	relatedID, subID string, subFunc SubFunc) error
+	relatedIDs []string, subID string, subFunc SubFunc) error
 
-// NewIdleQueueMock returns a queue mock which does nothing.
-func NewIdleQueueMock() QueueMock {
+// NewDummyQueueMock returns a queue mock which does nothing.
+func NewDummyQueueMock() QueueMock {
 	return func(method int, job *data.Job,
-		relatedID, subID string, subFunc SubFunc) error {
+		relatedIDs []string, subID string, subFunc SubFunc) error {
 		return nil
 	}
 }
 
 // Add is a mock implementation for the Add queue method.
-func (q QueueMock) Add(j *data.Job) error { return q(MockAdd, j, "", "", nil) }
+func (q QueueMock) Add(j *data.Job) error { return q(MockAdd, j, nil, "", nil) }
 
 // Process is a mock implementation for the Process queue method.
-func (q QueueMock) Process() error { return q(MockProcess, nil, "", "", nil) }
+func (q QueueMock) Process() error { return q(MockProcess, nil, nil, "", nil) }
 
 // Close is a mock implementation for the Close queue method.
-func (q QueueMock) Close() { q(MockClose, nil, "", "", nil) }
+func (q QueueMock) Close() { q(MockClose, nil, nil, "", nil) }
 
 // Subscribe is a mock implementation for the Subscribe queue method.
-func (q QueueMock) Subscribe(relatedID, subID string, subFunc SubFunc) error {
-	return q(MockSubscribe, nil, relatedID, subID, subFunc)
+func (q QueueMock) Subscribe(
+	relatedIDs []string, subID string, subFunc SubFunc) error {
+	return q(MockSubscribe, nil, relatedIDs, subID, subFunc)
 }
 
 // Unsubscribe is a mock implementation for the Unsubscribe queue method.
-func (q QueueMock) Unsubscribe(relatedID, subID string) error {
-	return q(MockUnsubscribe, nil, relatedID, subID, nil)
+func (q QueueMock) Unsubscribe(relatedIDs []string, subID string) error {
+	return q(MockUnsubscribe, nil, relatedIDs, subID, nil)
 }

--- a/ui/errors.go
+++ b/ui/errors.go
@@ -11,6 +11,7 @@ const (
 	ErrInternal
 	ErrAccountNotFound
 	ErrOfferingNotFound
+	ErrBadObjectType
 )
 
 var errMsgs = errors.Messages{
@@ -18,6 +19,7 @@ var errMsgs = errors.Messages{
 	ErrInternal:         "internal server error",
 	ErrAccountNotFound:  "account not found",
 	ErrOfferingNotFound: "offering not found",
+	ErrBadObjectType:    "bad object type",
 }
 
 func init() { errors.InjectMessages(errMsgs) }

--- a/ui/offering.go
+++ b/ui/offering.go
@@ -1,21 +1,21 @@
 package ui
 
 import (
-	"context"
-
-	"github.com/ethereum/go-ethereum/rpc"
-
 	"github.com/privatix/dappctrl/data"
 	"github.com/privatix/dappctrl/job"
 	"github.com/privatix/dappctrl/proc/worker"
 	"github.com/privatix/dappctrl/util"
 )
 
+// AcceptOfferingResult is an AcceptOffering result.
+type AcceptOfferingResult struct {
+	Channel string `json:"channel"`
+}
+
 // AcceptOffering initiates JobClientPreChannelCreate job and subscribes to job
 // results of the corresponding flow.
-func (h *Handler) AcceptOffering(ctx context.Context,
-	password, account, offering string,
-	gasPrice uint64) (*rpc.Subscription, error) {
+func (h *Handler) AcceptOffering(password, account, offering string,
+	gasPrice uint64) (*AcceptOfferingResult, error) {
 	logger := h.logger.Add("method", "AcceptOffering",
 		"account", account, "offering", offering, "gasPrice", gasPrice)
 
@@ -42,5 +42,5 @@ func (h *Handler) AcceptOffering(ctx context.Context,
 		return nil, ErrInternal
 	}
 
-	return h.subscribeToJobResults(ctx, logger, rid)
+	return &AcceptOfferingResult{rid}, nil
 }

--- a/ui/subscribe.go
+++ b/ui/subscribe.go
@@ -1,0 +1,93 @@
+package ui
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/ethereum/go-ethereum/rpc"
+	"gopkg.in/reform.v1"
+
+	"github.com/privatix/dappctrl/data"
+	"github.com/privatix/dappctrl/util/rpcsrv"
+)
+
+// ObjectChangeResult is an ObjectChange notification result.
+type ObjectChangeResult struct {
+	Object json.RawMessage `json:"object,omitempty"`
+	Job    *data.Job       `json:"job"`
+	Error  *rpcsrv.Error   `json:"error,omitempty"`
+}
+
+var objectChangeTables = map[string]reform.Table{
+	data.JobOffering: data.OfferingTable,
+	data.JobChannel:  data.ChannelTable,
+	data.JobEndpoint: data.EndpointTable,
+	data.JobAccount:  data.AccountTable,
+}
+
+// ObjectChange subscribes to changes for objects of a given type.
+func (h *Handler) ObjectChange(ctx context.Context, password, objectType string,
+	objectIDs []string) (*rpc.Subscription, error) {
+	logger := h.logger.Add("method", "ObjectChange",
+		"objectType", objectType, "objectIDs", objectIDs)
+
+	if err := h.checkPassword(logger, password); err != nil {
+		return nil, err
+	}
+
+	table, ok := objectChangeTables[objectType]
+	if !ok {
+		logger.Warn(ErrBadObjectType.Error())
+		return nil, ErrBadObjectType
+	}
+
+	ntf, ok := rpc.NotifierFromContext(ctx)
+	if !ok {
+		logger.Error("no notifier found in context")
+		return nil, ErrInternal
+	}
+
+	sub := ntf.CreateSubscription()
+	cb := func(job *data.Job, result error) {
+		obj, err := h.db.FindByPrimaryKeyFrom(table, job.RelatedID)
+		if err != nil {
+			logger.Error(err.Error())
+		}
+
+		var odata json.RawMessage
+		if obj != nil {
+			odata, err = json.Marshal(obj)
+			if err != nil {
+				logger.Error(err.Error())
+			}
+		}
+
+		err = ntf.Notify(sub.ID,
+			&ObjectChangeResult{odata, job, rpcsrv.ToError(result)})
+		if err != nil {
+			logger.Warn(err.Error())
+		}
+	}
+
+	sid := string(sub.ID)
+	err := h.queue.Subscribe(objectIDs, sid, cb)
+	if err != nil {
+		logger.Error(err.Error())
+		return nil, ErrInternal
+	}
+
+	go func() {
+		for err, ok := <-sub.Err(); ok; {
+			if err != nil {
+				logger.Warn(err.Error())
+			}
+		}
+
+		err := h.queue.Unsubscribe(objectIDs, sid)
+		if err != nil {
+			logger.Error(err.Error())
+		}
+	}()
+
+	return sub, nil
+}

--- a/ui/subscribe_test.go
+++ b/ui/subscribe_test.go
@@ -1,0 +1,72 @@
+package ui
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/privatix/dappctrl/data"
+	"github.com/privatix/dappctrl/job"
+	"github.com/privatix/dappctrl/util"
+)
+
+func TestObjectChange(t *testing.T) {
+	fxt := newFixture(t)
+	defer fxt.close()
+
+	unsubscribed := false
+	j1 := &data.Job{RelatedID: fxt.Channel.ID}
+	j2 := &data.Job{RelatedID: util.NewUUID()}
+	handler.queue = job.QueueMock(func(method int, j3 *data.Job,
+		relatedIDs []string, subID string, subFunc job.SubFunc) error {
+		switch method {
+		case job.MockSubscribe:
+			go func() {
+				time.Sleep(time.Millisecond)
+				subFunc(j1, nil)
+				subFunc(j2, errors.New("some error"))
+			}()
+		case job.MockUnsubscribe:
+			unsubscribed = true
+		default:
+			t.Fatal("unexpected queue call")
+		}
+		return nil
+	})
+
+	ch := make(chan *ObjectChangeResult)
+	_, err := subscribe(client, ch, "objectChange",
+		"bad-password", data.JobChannel, nil)
+	util.TestExpectResult(t, "ObjectChange", ErrAccessDenied, err)
+
+	_, err = subscribe(client, ch, "objectChange",
+		data.TestPassword, "bad-object-type", nil)
+	util.TestExpectResult(t, "ObjectChange", ErrBadObjectType, err)
+
+	sub, err := subscribe(client, ch, "objectChange", data.TestPassword,
+		data.JobChannel, []string{j1.RelatedID, j2.RelatedID})
+	util.TestExpectResult(t, "ObjectChange", nil, err)
+
+	var ch2 data.Channel
+
+	ret := <-ch
+	util.TestUnmarshalJSON(t, []byte(ret.Object), &ch2)
+	if ret.Object == nil || ch2.ID != j1.RelatedID ||
+		ret.Job == nil || ret.Error != nil {
+		t.Fatalf("wrong data for the first notification")
+	}
+
+	ret = <-ch
+	util.TestUnmarshalJSON(t, []byte(ret.Object), &ch2)
+	if ret.Object != nil || ret.Job == nil ||
+		ret.Error.Message != "some error" {
+		t.Fatalf("wrong data for the second notification")
+	}
+
+	sub.Unsubscribe()
+	time.Sleep(time.Millisecond)
+
+	if !unsubscribed {
+		t.Fatal("didn't unsubscribe")
+	}
+}

--- a/util/test.go
+++ b/util/test.go
@@ -3,6 +3,7 @@
 package util
 
 import (
+	"encoding/json"
 	"flag"
 	"log"
 	"testing"
@@ -38,5 +39,15 @@ func TestExpectResult(t *testing.T, op string, expected, actual error) {
 	if expected != actual && !sameContent {
 		t.Fatalf("unexpected '%s' result: expected '%v', returned "+
 			"'%v' (%s)", op, expected, actual, Caller())
+	}
+}
+
+// TestUnmarshalJSON unmarshals a given JSON into a given object.
+func TestUnmarshalJSON(t *testing.T, data []byte, v interface{}) {
+	if data != nil {
+		if err := json.Unmarshal(data, v); err != nil {
+			t.Errorf("failed to unmarshal JSON: '%s' (%s)",
+				err, Caller())
+		}
 	}
 }


### PR DESCRIPTION
This change includes:
1. Queue now supports multi-object subscriptions per single call.
2. Implementation for the new `objectChange` subscription type.
3. The `acceptOffering` method doesn't support subscriptions.

**Note**:
	The changes correspond to the following UI API:
	https://github.com/Privatix/dappctrl/wiki/JSON-RPC
	https://github.com/Privatix/dappctrl/wiki/UI-JSON-RPC