### PR TITLE
Add GetEndpointMessage method and mock to connector.

### DIFF
--- a/svc/connector/connector.go
+++ b/svc/connector/connector.go
@@ -3,6 +3,7 @@
 package connector
 
 import (
+	"github.com/privatix/dappctrl/data"
 	"github.com/privatix/dappctrl/sesssrv"
 	"github.com/privatix/dappctrl/util/log"
 	"github.com/privatix/dappctrl/util/srv"
@@ -28,6 +29,9 @@ type Connector interface {
 	// SetupProductConfiguration send common server configuration
 	// used by client access message.
 	SetupProductConfiguration(args *sesssrv.ProductArgs) error
+	// GetEndpointMessage returns endpoint message by channel identificator.
+	GetEndpointMessage(
+		args *sesssrv.EndpointMsgArgs) (*data.Endpoint, error)
 }
 
 type cntr struct {
@@ -77,4 +81,13 @@ func (c *cntr) UpdateSessionUsage(args *sesssrv.UpdateArgs) error {
 func (c *cntr) SetupProductConfiguration(args *sesssrv.ProductArgs) error {
 	return sesssrv.Post(c.config.Config, c.logger, c.config.Username,
 		c.config.Password, sesssrv.PathProductConfig, args, nil)
+}
+
+// GetEndpointMessage returns endpoint message by channel identificator.
+func (c *cntr) GetEndpointMessage(
+	args *sesssrv.EndpointMsgArgs) (*data.Endpoint, error) {
+	var endpoint *data.Endpoint
+	err := sesssrv.Post(c.config.Config, c.logger, c.config.Username,
+		c.config.Password, sesssrv.PathProductConfig, args, &endpoint)
+	return endpoint, err
 }

--- a/svc/connector/test.go
+++ b/svc/connector/test.go
@@ -1,0 +1,51 @@
+package connector
+
+import (
+	"github.com/privatix/dappctrl/data"
+	"github.com/privatix/dappctrl/sesssrv"
+)
+
+// Mock is a mock implementation for Connector interface.
+type Mock struct {
+	Error    error
+	Endpoint *data.Endpoint
+}
+
+// NewMock returns mock for Connector interface.
+func NewMock() *Mock {
+	return &Mock{}
+}
+
+// AuthSession is a mock implementation for the AuthSession connector method.
+func (m *Mock) AuthSession(args *sesssrv.AuthArgs) error {
+	return m.Error
+}
+
+// StartSession is a mock implementation for the StartSession connector method.
+func (m *Mock) StartSession(args *sesssrv.StartArgs) error {
+	return m.Error
+}
+
+// StopSession is a mock implementation for the StopSession connector method.
+func (m *Mock) StopSession(args *sesssrv.StopArgs) error {
+	return m.Error
+}
+
+// UpdateSessionUsage is a mock implementation
+// for the UpdateSessionUsage connector method.
+func (m *Mock) UpdateSessionUsage(args *sesssrv.UpdateArgs) error {
+	return m.Error
+}
+
+// SetupProductConfiguration is a mock implementation
+// for the SetupProductConfiguration connector method.
+func (m *Mock) SetupProductConfiguration(args *sesssrv.ProductArgs) error {
+	return m.Error
+}
+
+// GetEndpointMessage is a mock implementation
+// for the GetEndpointMessage connector method.
+func (m *Mock) GetEndpointMessage(
+	args *sesssrv.EndpointMsgArgs) (*data.Endpoint, error) {
+	return m.Endpoint, m.Error
+}


### PR DESCRIPTION
Resolves BV-689.
The method is required for the interaction of a client-specific openvpn adapter and a controller.