### PR TITLE
Assign bandwidth limit on client VPN connections

### DIFF
--- a/data/prod_data.sql
+++ b/data/prod_data.sql
@@ -8,8 +8,19 @@ VALUES ('efc61769-96c8-4c0d-b50a-e4d11fc30523',
             "schema": {
                 "properties": {
                     "additionalParams": {
-                        "default": "{}",
-                        "type": "string"
+                        "default": {
+                            "minUploadMbps": 1,
+                            "minDownloadMbps": 1
+                        },
+                        "minUploadMbps": {
+                            "title": "minimum upload speed (Mbps)",
+                            "type": number
+                        },
+                        "minDownloadMbps": {
+                            "title": "minimum download speed (Mbps)",
+                            "type": number
+                        },
+                        "type": "object"
                     },
                     "agent": {
                         "title": "agent uuid",

--- a/data/schema.go
+++ b/data/schema.go
@@ -107,34 +107,34 @@ const (
 // Offering is a service offering.
 //reform:offerings
 type Offering struct {
-	ID                 string  `json:"id" reform:"id,pk"`
-	IsLocal            bool    `json:"is_local" reform:"is_local"`
-	Template           string  `json:"template" reform:"tpl" validate:"required"`    // Offering's.
-	Product            string  `json:"product" reform:"product" validate:"required"` // Specific billing and actions.
-	Hash               string  `json:"hash" reform:"hash"`                           // Offering's hash.
-	Status             string  `json:"status" reform:"status"`
-	OfferStatus        string  `json:"offerStatus" reform:"offer_status"`
-	BlockNumberUpdated uint64  `json:"blockNumberUpdated" reform:"block_number_updated"`
-	Agent              string  `json:"agent" reform:"agent" validate:"required"`
-	RawMsg             string  `json:"rawMsg" reform:"raw_msg"`
-	ServiceName        string  `json:"serviceName" reform:"service_name" validate:"required"`
-	Description        *string `json:"description" reform:"description"`
-	Country            string  `json:"country" reform:"country" validate:"required"` // ISO 3166-1 alpha-2.
-	Supply             uint16  `json:"supply" reform:"supply" validate:"required"`
-	CurrentSupply      uint16  `json:"currentSupply" reform:"current_supply"`
-	UnitName           string  `json:"unitName" reform:"unit_name" validate:"required"` // Like megabytes, minutes, etc.
-	UnitType           string  `json:"unitType" reform:"unit_type" validate:"required"`
-	BillingType        string  `json:"billingType" reform:"billing_type" validate:"required"`
-	SetupPrice         uint64  `json:"setupPrice" reform:"setup_price"` // Setup fee.
-	UnitPrice          uint64  `json:"unitPrice" reform:"unit_price"`
-	MinUnits           uint64  `json:"minUnits" reform:"min_units" validate:"required"`
-	MaxUnit            *uint64 `json:"maxUnit" reform:"max_unit"`
-	BillingInterval    uint    `json:"billingInterval" reform:"billing_interval" validate:"required"` // Every unit number to be paid.
-	MaxBillingUnitLag  uint    `json:"maxBillingUnitLag" reform:"max_billing_unit_lag"`               // Max maximum tolerance for payment lag.
-	MaxSuspendTime     uint    `json:"maxSuspendTime" reform:"max_suspended_time"`                    // In seconds.
-	MaxInactiveTimeSec *uint64 `json:"maxInactiveTimeSec" reform:"max_inactive_time_sec"`
-	FreeUnits          uint8   `json:"freeUnits" reform:"free_units"`
-	AdditionalParams   []byte  `json:"additionalParams" reform:"additional_params" validate:"required"`
+	ID                 string          `json:"id" reform:"id,pk"`
+	IsLocal            bool            `json:"is_local" reform:"is_local"`
+	Template           string          `json:"template" reform:"tpl" validate:"required"`    // Offering's.
+	Product            string          `json:"product" reform:"product" validate:"required"` // Specific billing and actions.
+	Hash               string          `json:"hash" reform:"hash"`                           // Offering's hash.
+	Status             string          `json:"status" reform:"status"`
+	OfferStatus        string          `json:"offerStatus" reform:"offer_status"`
+	BlockNumberUpdated uint64          `json:"blockNumberUpdated" reform:"block_number_updated"`
+	Agent              string          `json:"agent" reform:"agent" validate:"required"`
+	RawMsg             string          `json:"rawMsg" reform:"raw_msg"`
+	ServiceName        string          `json:"serviceName" reform:"service_name" validate:"required"`
+	Description        *string         `json:"description" reform:"description"`
+	Country            string          `json:"country" reform:"country" validate:"required"` // ISO 3166-1 alpha-2.
+	Supply             uint16          `json:"supply" reform:"supply" validate:"required"`
+	CurrentSupply      uint16          `json:"currentSupply" reform:"current_supply"`
+	UnitName           string          `json:"unitName" reform:"unit_name" validate:"required"` // Like megabytes, minutes, etc.
+	UnitType           string          `json:"unitType" reform:"unit_type" validate:"required"`
+	BillingType        string          `json:"billingType" reform:"billing_type" validate:"required"`
+	SetupPrice         uint64          `json:"setupPrice" reform:"setup_price"` // Setup fee.
+	UnitPrice          uint64          `json:"unitPrice" reform:"unit_price"`
+	MinUnits           uint64          `json:"minUnits" reform:"min_units" validate:"required"`
+	MaxUnit            *uint64         `json:"maxUnit" reform:"max_unit"`
+	BillingInterval    uint            `json:"billingInterval" reform:"billing_interval" validate:"required"` // Every unit number to be paid.
+	MaxBillingUnitLag  uint            `json:"maxBillingUnitLag" reform:"max_billing_unit_lag"`               // Max maximum tolerance for payment lag.
+	MaxSuspendTime     uint            `json:"maxSuspendTime" reform:"max_suspended_time"`                    // In seconds.
+	MaxInactiveTimeSec *uint64         `json:"maxInactiveTimeSec" reform:"max_inactive_time_sec"`
+	FreeUnits          uint8           `json:"freeUnits" reform:"free_units"`
+	AdditionalParams   json.RawMessage `json:"additionalParams" reform:"additional_params" validate:"required"`
 }
 
 // State channel statuses.

--- a/sesssrv/client.go
+++ b/sesssrv/client.go
@@ -38,10 +38,13 @@ func Post(conf *srv.Config, logger log.Logger, username, password, path string,
 		return nil
 	}
 
-	err = json.Unmarshal(resp.Result, result)
-	if err != nil {
-		logger.Error(err.Error())
-		return ErrDecodeResponse
+	if result != nil {
+		err = json.Unmarshal(resp.Result, result)
+		if err != nil {
+			logger.Error(err.Error())
+			return ErrDecodeResponse
+		}
 	}
+
 	return nil
 }

--- a/sesssrv/session_test.go
+++ b/sesssrv/session_test.go
@@ -84,11 +84,16 @@ func testStartNormalFlow(fxt *data.TestFixture) *data.Session {
 		ClientPort: clientPort,
 	}
 
+	var res StartResult
 	before := time.Now()
 	err := Post(conf.SessionServer.Config, logger,
-		fxt.Product.ID, data.TestPassword, PathStart, args2, nil)
+		fxt.Product.ID, data.TestPassword, PathStart, args2, &res)
 	util.TestExpectResult(fxt.T, "Post", nil, err)
 	after := time.Now()
+
+	if res.Offering == nil || res.Offering.ID != fxt.Channel.Offering {
+		fxt.T.Fatal("bad start result offering")
+	}
 
 	var sess data.Session
 	if err := db.FindOneTo(&sess, "channel", fxt.Channel.ID); err != nil {

--- a/svc/dappvpn/config/config.go
+++ b/svc/dappvpn/config/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/privatix/dappctrl/svc/dappvpn/mon"
 	"github.com/privatix/dappctrl/svc/dappvpn/msg"
+	"github.com/privatix/dappctrl/tc"
 	"github.com/privatix/dappctrl/util"
 	"github.com/privatix/dappctrl/util/log"
 	"github.com/privatix/dappctrl/util/srv"
@@ -26,20 +27,21 @@ type serverConfig struct {
 // Config is dappvpn configuration.
 type Config struct {
 	ChannelDir string // Directory for common-name -> channel mappings.
-	Log        *util.LogConfig
 	FileLog    *log.FileConfig
+	Log        *util.LogConfig
 	Monitor    *mon.Config
 	OpenVPN    *ovpnConfig // OpenVPN settings for client mode.
 	Pusher     *msg.Config
 	Server     *serverConfig
+	TC         *tc.Config
 }
 
 // NewConfig creates default dappvpn configuration.
 func NewConfig() *Config {
 	return &Config{
 		ChannelDir: ".",
-		Log:        util.NewLogConfig(),
 		FileLog:    log.NewFileConfig(),
+		Log:        util.NewLogConfig(),
 		Monitor:    mon.NewConfig(),
 		OpenVPN: &ovpnConfig{
 			Name:       "openvpn",
@@ -48,5 +50,6 @@ func NewConfig() *Config {
 		},
 		Pusher: msg.NewConfig(),
 		Server: &serverConfig{Config: srv.NewConfig()},
+		TC:     tc.NewConfig(),
 	}
 }

--- a/svc/dappvpn/data/offering.go
+++ b/svc/dappvpn/data/offering.go
@@ -1,0 +1,7 @@
+package data
+
+// OfferingParams is an offering additional parameters for VPN.
+type OfferingParams struct {
+	MinUploadMbits   int `json:"minUploadMbits"`
+	MinDownloadMbits int `json:"minDownloadMbits"`
+}

--- a/tc/errors.go
+++ b/tc/errors.go
@@ -1,0 +1,15 @@
+package tc
+
+import "github.com/privatix/dappctrl/util/errors"
+
+// Errors.
+const (
+	// CRC16("github.com/privatix/dappctrl/tc") = 0xB8DC
+	ErrBadClientIP errors.Error = 0xB8DC<<8 + iota
+)
+
+var errMsgs = errors.Messages{
+	ErrBadClientIP: "bad client IP",
+}
+
+func init() { errors.InjectMessages(errMsgs) }

--- a/tc/tc.go
+++ b/tc/tc.go
@@ -1,0 +1,41 @@
+package tc
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+
+	"github.com/privatix/dappctrl/util/log"
+)
+
+// TrafficControl is a traffic control utility.
+type TrafficControl struct {
+	conf   *Config
+	logger log.Logger
+}
+
+// NewTrafficControl creates a new TrafficControl instance.
+func NewTrafficControl(conf *Config, logger log.Logger) *TrafficControl {
+	return &TrafficControl{conf, logger.Add("type", "tc/TrafficControl")}
+}
+
+func (tc *TrafficControl) run(logger log.Logger,
+	name string, args ...string) (stdout string, err error) {
+	logger = logger.Add("cmd", name, "args", args)
+
+	cmd := exec.Command(name, args...)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	out, err := cmd.Output()
+
+	lines := strings.TrimSpace(stderr.String())
+	for _, line := range strings.Split(lines, "\n") {
+		if len(line) != 0 {
+			logger.Warn(line)
+		}
+	}
+
+	return string(out), err
+}

--- a/tc/tc_darwin.go
+++ b/tc/tc_darwin.go
@@ -1,0 +1,23 @@
+package tc
+
+// Config is a traffic control configuration.
+type Config struct {
+}
+
+// NewConfig creates a default configuration.
+func NewConfig() *Config {
+	return &Config{}
+}
+
+// SetRateLimit sets a rate limit for a given client IP address on a given
+// network interface.
+func (tc *TrafficControl) SetRateLimit(
+	iface, clientIP string, upMbps, downMbps int) error {
+	return nil
+}
+
+// UnsetRateLimit removes a rate limit for a given client IP address on a given
+// network interface.
+func (tc *TrafficControl) UnsetRateLimit(iface, clientIP string) error {
+	return nil
+}

--- a/tc/tc_linux.go
+++ b/tc/tc_linux.go
@@ -1,0 +1,103 @@
+package tc
+
+import (
+	"fmt"
+	"hash/crc32"
+	"net"
+	"strings"
+)
+
+// Config is a traffic control configuration.
+type Config struct {
+	TcPath       string
+	IptablesPath string
+}
+
+// NewConfig creates a default configuration.
+func NewConfig() *Config {
+	return &Config{
+		TcPath:       "/sbin/tc",
+		IptablesPath: "/sbin/iptables",
+	}
+}
+
+// See http://tldp.org/HOWTO/Traffic-Control-HOWTO/ as reference.
+
+// SetRateLimit sets a rate limit for a given client IP address on a given
+// network interface.
+func (tc *TrafficControl) SetRateLimit(
+	iface, clientIP string, upMbps, downMbps int) error {
+	logger := tc.logger.Add("method", "SetRateLimit", "iface", iface,
+		"clientIp", clientIP, "up", upMbps, "down", downMbps)
+
+	ip := net.ParseIP(clientIP)
+	if ip == nil {
+		return ErrBadClientIP
+	}
+
+	out, err := tc.run(logger, tc.conf.TcPath,
+		"-s", "-d", "qdisc", "show", "dev", iface)
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasPrefix(out, "qdisc htb 1: root ") {
+		logger.Info("setting a root htb discipline")
+		_, err := tc.run(logger, tc.conf.TcPath, "qdisc",
+			"add", "dev", iface, "root", "handle", "1:", "htb")
+		if err != nil {
+			return err
+		}
+	}
+
+	cid := classID(ip)
+	rate := fmt.Sprintf("%dMbit", downMbps)
+	_, err = tc.run(logger, tc.conf.TcPath,
+		"class", "add", "dev", iface, "parent", "1:",
+		"classid", cid, "htb", "rate", rate, "ceil", rate)
+	if err != nil {
+		return err
+	}
+
+	_, err = tc.run(logger, tc.conf.IptablesPath,
+		"-t", "mangle", "-A", "POSTROUTING", "-o", iface,
+		"-d", withMask(ip), "-j", "CLASSIFY", "--set-class", cid)
+
+	return err
+}
+
+// UnsetRateLimit removes a rate limit for a given client IP address on a given
+// network interface.
+func (tc *TrafficControl) UnsetRateLimit(iface, clientIP string) error {
+	logger := tc.logger.Add("method", "UnsetRateLimit",
+		"iface", iface, "clientIp", clientIP)
+
+	ip := net.ParseIP(clientIP)
+	if ip == nil {
+		return ErrBadClientIP
+	}
+
+	cid := classID(ip)
+	_, err := tc.run(logger, tc.conf.IptablesPath,
+		"-t", "mangle", "-D", "POSTROUTING", "-o", iface,
+		"-d", withMask(ip), "-j", "CLASSIFY", "--set-class", cid)
+	if err != nil {
+		return err
+	}
+
+	_, err = tc.run(logger, tc.conf.TcPath,
+		"qdisc", "del", "dev", iface, "root", "handle", cid, "htb")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func classID(ip net.IP) string {
+	return fmt.Sprintf("1:%x", uint16(crc32.ChecksumIEEE(ip)))
+}
+
+func withMask(ip net.IP) string {
+	return fmt.Sprintf("%s/%d", ip, len(ip))
+}

--- a/tc/tc_windows.go
+++ b/tc/tc_windows.go
@@ -1,0 +1,23 @@
+package tc
+
+// Config is a traffic control configuration.
+type Config struct {
+}
+
+// NewConfig creates a default configuration.
+func NewConfig() *Config {
+	return &Config{}
+}
+
+// SetRateLimit sets a rate limit for a given client IP address on a given
+// network interface.
+func (tc *TrafficControl) SetRateLimit(
+	iface, clientIP string, upMbps, downMbps int) error {
+	return nil
+}
+
+// UnsetRateLimit removes a rate limit for a given client IP address on a given
+// network interface.
+func (tc *TrafficControl) UnsetRateLimit(iface, clientIP string) error {
+	return nil
+}


### PR DESCRIPTION
This is an initial implementation of traffic control for the client VPN sessions. Currently only download rate is constrained and on Linux only.

This commit includes the following changes:
1. The start session call now returns an offering.
2. Added a new `tc` package for traffic control.
3. Dappvpn calls SetRateLimit/UnsetRateLimit.

Resolves BV-786.