### PR TITLE
commands to downgrade the database schema and display version

### DIFF
--- a/data/command.go
+++ b/data/command.go
@@ -13,13 +13,10 @@ import (
 	reform "gopkg.in/reform.v1"
 )
 
-type cmdFlag int
-
-// cmdFlags enum
-const (
-	ConnectionString cmdFlag = iota
-	Version
-)
+type cmdFlag struct {
+	connection string
+	version    int64
+}
 
 // ExecuteCommand executes commands to manage database
 // db-migrate - command to execute migration scripts
@@ -32,22 +29,21 @@ func ExecuteCommand(args []string) error {
 
 	switch args[0] {
 	case "db-migrate":
-		m := readFlags(args)
-		connStr := m[ConnectionString]
-		version, _ := strconv.ParseInt(m[Version], 10, 64)
-		if err := migration.Migrate(connStr, version); err != nil {
+		f := readFlags(args)
+		err := migration.Migrate(f.connection, f.version)
+		if err != nil {
 			panic(fmt.Sprintf("failed to run migration %s", err))
 		}
 		os.Exit(0)
 	case "db-init-data":
-		connStr := readFlags(args)[ConnectionString]
-		if err := initData(connStr); err != nil {
+		f := readFlags(args)
+		if err := initData(f.connection); err != nil {
 			panic(fmt.Sprintf("failed to init database %s", err))
 		}
 		os.Exit(0)
 	case "db-version":
-		connStr := readFlags(args)[ConnectionString]
-		version, err := migration.Version(connStr)
+		f := readFlags(args)
+		version, err := migration.Version(f.connection)
 		if err != nil {
 			msg := "failed to print database schema version"
 			panic(fmt.Sprintf("%s %s", msg, err))
@@ -58,7 +54,7 @@ func ExecuteCommand(args []string) error {
 	return nil
 }
 
-func readFlags(args []string) map[cmdFlag]string {
+func readFlags(args []string) *cmdFlag {
 	connStr := flag.String("conn", "", "Database connection string")
 	version := flag.Int("version", 0, "Migrate to version")
 
@@ -68,12 +64,10 @@ func readFlags(args []string) map[cmdFlag]string {
 		panic(errors.New("connection string is not detected"))
 	}
 
-	m := make(map[cmdFlag]string)
-
-	m[ConnectionString] = *connStr
-	m[Version] = strconv.Itoa(*version)
-
-	return m
+	return &cmdFlag{
+		connection: *connStr,
+		version:    int64(*version),
+	}
 }
 
 func initData(connStr string) error {


### PR DESCRIPTION
This commit includes the following changes:

1.  `db-version` - command to display version of the database schema
2.  executing migration scripts to upgrade/downgrade database schema.

Resolves BV-858.