### PR TITLE
Checking offering country by IP address from endpoint message.

### DIFF
--- a/country/country.go
+++ b/country/country.go
@@ -1,0 +1,77 @@
+package country
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// UndefinedCountry is default country code.
+// This means that a country is not defined.
+const UndefinedCountry = "ZZ"
+
+// Config is the configuration for obtaining a country code.
+type Config struct {
+	Field   string
+	Timeout uint64 // in seconds.
+	// In a url template there should be an pattern {{ip}}.
+	// Pattern {{ip}} will be replaced by a ip address of the agent.
+	URLTemplate string
+}
+
+// NewConfig creates new configuration for obtaining a country code.
+func NewConfig() *Config {
+	return &Config{
+		Timeout: 30,
+	}
+}
+
+func do(ctx context.Context, req *http.Request) (*http.Response, error) {
+	res, err := http.DefaultClient.Do(req.WithContext(ctx))
+	if err != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+// GetCountry returns country code by ip.
+// Parses response in JSON format and returns a value of the field.
+func GetCountry(timeout uint64, url, field string) (string, error) {
+	ctx, cancel := context.WithTimeout(
+		context.Background(), time.Second*time.Duration(timeout))
+	defer cancel()
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	res, err := do(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+
+	object := make(map[string]interface{})
+	if err := json.NewDecoder(res.Body).Decode(&object); err != nil {
+		return "", err
+	}
+
+	f, ok := object[field]
+	if !ok {
+		return "", ErrMissingRequiredField
+	}
+
+	country, ok := f.(string)
+	if !ok {
+		return "", ErrBadCountryValueType
+	}
+
+	return strings.TrimSpace(strings.ToUpper(country)), nil
+}

--- a/country/errors.go
+++ b/country/errors.go
@@ -1,0 +1,20 @@
+package country
+
+import "github.com/privatix/dappctrl/util/errors"
+
+// Errors returned by workers.
+const (
+	ErrInternal errors.Error = 0xFFDA<<8 + iota
+	ErrMissingRequiredField
+	ErrBadCountryValueType
+)
+
+var errMsgs = errors.Messages{
+	ErrInternal:             "internal server error",
+	ErrMissingRequiredField: "missing required field",
+	ErrBadCountryValueType:  "country value is not a string",
+}
+
+func init() {
+	errors.InjectMessages(errMsgs)
+}

--- a/country/test.go
+++ b/country/test.go
@@ -1,0 +1,29 @@
+// +build !notest
+
+package country
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+)
+
+// ServerMock it is mock for processing a request for country detection.
+type ServerMock struct {
+	Server *httptest.Server
+}
+
+// NewServerMock creates new ServerMock.
+func NewServerMock(field, result string) *ServerMock {
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, fmt.Sprintf(`{"%s": "%s"}`,
+				field, result))
+		}))
+	return &ServerMock{ts}
+}
+
+// Close closed ServerMock.
+func (s ServerMock) Close() {
+	s.Server.Close()
+}

--- a/dappctrl-dev.config.json
+++ b/dappctrl-dev.config.json
@@ -21,7 +21,7 @@
     "Country": {
         "Field" : "country_code",
         "Timeout": 30,
-        "URL" : "https://ipleak.net/json"
+        "URLTemplate" : "https://ipleak.net/json/{{ip}}"
     },
     "DB": {
         "Conn": {

--- a/dappctrl.config.json
+++ b/dappctrl.config.json
@@ -21,7 +21,7 @@
     "Country": {
         "Field" : "country_code",
         "Timeout": 30,
-        "URL" : "https://ipleak.net/json"
+        "URLTemplate" : "https://ipleak.net/json/{{ip}}"
     },
     "DB": {
         "Conn": {

--- a/data/migration/scripts/00001_schema_down.sql
+++ b/data/migration/scripts/00001_schema_down.sql
@@ -34,4 +34,5 @@ DROP TYPE unit_type;
 DROP TYPE bill_type;
 DROP TYPE tpl_kind;
 DROP TYPE usage_rep_type;
+DROP TYPE country_status_type;
 

--- a/data/migration/scripts/00001_schema_up.sql
+++ b/data/migration/scripts/00001_schema_up.sql
@@ -19,6 +19,9 @@ CREATE TYPE contract_type AS ENUM ('ptc','psc');
 -- Client identification types.
 CREATE TYPE client_ident_type AS ENUM ('by_channel_id');
 
+-- Country status types.
+CREATE TYPE country_status_type AS ENUM ('unknown', 'valid', 'invalid');
+
 -- SHA3-256 in base64 (RFC-4648).
 CREATE DOMAIN sha3_256 AS char(44);
 

--- a/data/schema.go
+++ b/data/schema.go
@@ -75,6 +75,7 @@ type Product struct {
 	ClientIdent            string          `json:"clientIdent" reform:"client_ident"`
 	Config                 json.RawMessage `json:"config" reform:"config"`
 	ServiceEndpointAddress *string         `json:"serviceEndpointAddress" reform:"service_endpoint_address"`
+	Country                *string         `json:"country" reform:"country"`
 }
 
 // Unit used for billing calculation.
@@ -227,6 +228,13 @@ type Setting struct {
 	Name        string  `json:"name" reform:"name"`
 }
 
+// Country statuses.
+const (
+	CountryStatusUnknown = "unknown"
+	CountryStatusValid   = "valid"
+	CountryStatusInvalid = "invalid"
+)
+
 // Endpoint messages is info about service access.
 //reform:endpoints
 type Endpoint struct {
@@ -241,6 +249,7 @@ type Endpoint struct {
 	Username               *string `json:"username" reform:"username"`
 	Password               *string `json:"password" reform:"password"`
 	AdditionalParams       []byte  `json:"additionalParams" reform:"additional_params"`
+	CountryStatus          *string `json:"countryStatus" reform:"country_status"`
 }
 
 // EndpointUI contains only certain fields of endpoints table.

--- a/data/schema.sql
+++ b/data/schema.sql
@@ -18,6 +18,9 @@ CREATE TYPE contract_type AS ENUM ('ptc','psc');
 -- Client identification types.
 CREATE TYPE client_ident_type AS ENUM ('by_channel_id');
 
+-- Country status types.
+CREATE TYPE country_status_type AS ENUM ('unknown', 'valid', 'invalid');
+
 -- SHA3-256 in base64 (RFC-4648).
 CREATE DOMAIN sha3_256 AS char(44);
 
@@ -167,7 +170,8 @@ CREATE TABLE products (
     password bcrypt_hash NOT NULL,
     client_ident client_ident_type NOT NULL,
     config json,  -- Store configuration of product --
-    service_endpoint_address varchar(106) -- address ("hostname") of service endpoint. Can be dns or IP.
+    service_endpoint_address varchar(106), -- address ("hostname") of service endpoint. Can be dns or IP.
+    country char(2) -- ISO 3166-1 alpha-2
 );
 
 -- Service offerings.
@@ -285,7 +289,8 @@ CREATE TABLE endpoints (
     username varchar(100),
     password varchar(48),
     additional_params json, -- all additional parameters stored as JSON
-    raw_msg text NOT NULL -- raw message in base64 (RFC-4648)
+    raw_msg text NOT NULL, -- raw message in base64 (RFC-4648)
+    country_status country_status_type -- result of checking a country by agent`s ip address.
 );
 
 -- Job queue.

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	abill "github.com/privatix/dappctrl/agent/bill"
 	cbill "github.com/privatix/dappctrl/client/bill"
 	"github.com/privatix/dappctrl/client/svcrun"
+	"github.com/privatix/dappctrl/country"
 	"github.com/privatix/dappctrl/data"
 	dblog "github.com/privatix/dappctrl/data/log"
 	"github.com/privatix/dappctrl/eth"
@@ -66,7 +67,7 @@ type config struct {
 	SOMC          *somc.Config
 	StaticPasword string
 	UI            *ui.Config
-	Country       *worker.CountryConfig
+	Country       *country.Config
 }
 
 func newConfig() *config {
@@ -88,7 +89,7 @@ func newConfig() *config {
 		SessionServer: sesssrv.NewConfig(),
 		SOMC:          somc.NewConfig(),
 		UI:            ui.NewConfig(),
-		Country:       worker.NewCountryConfig(),
+		Country:       country.NewConfig(),
 	}
 }
 
@@ -283,7 +284,7 @@ func main() {
 		defer cmon.Close()
 	}
 
-	sess := sesssrv.NewServer(conf.SessionServer, logger, db)
+	sess := sesssrv.NewServer(conf.SessionServer, logger, db, conf.Country)
 	go func() {
 		fatal <- sess.ListenAndServe()
 	}()

--- a/proc/worker/agent.go
+++ b/proc/worker/agent.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 
+	"github.com/privatix/dappctrl/country"
 	"github.com/privatix/dappctrl/data"
 	"github.com/privatix/dappctrl/eth"
 	"github.com/privatix/dappctrl/messages"
@@ -20,8 +21,6 @@ import (
 	"github.com/privatix/dappctrl/util"
 	"github.com/privatix/dappctrl/util/log"
 )
-
-const defaultCountry = "ZZ"
 
 // AgentAfterChannelCreate registers client and creates pre service create job.
 func (w *Worker) AgentAfterChannelCreate(job *data.Job) error {
@@ -577,12 +576,16 @@ func (w *Worker) AgentPreOfferingMsgBCPublish(job *data.Job) error {
 		return err
 	}
 
-	country, err := w.getCountry()
+	product, err := w.productByPK(logger, offering.Product)
 	if err != nil {
-		country = defaultCountry
+		return err
 	}
 
-	offering.Country = country
+	offering.Country = country.UndefinedCountry
+
+	if product.Country != nil && len(*product.Country) == 2 {
+		offering.Country = *product.Country
+	}
 
 	msg := offer.OfferingMessage(agent, template, offering)
 

--- a/proc/worker/agent_test.go
+++ b/proc/worker/agent_test.go
@@ -3,10 +3,7 @@ package worker
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"math/big"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -459,20 +456,6 @@ func TestAgentPreOfferingMsgBCPublish(t *testing.T) {
 	// 1. PSC.registerServiceOffering()
 	// 2. msg_status="bchain_publishing"
 	// 3. offer_status="registered"
-
-	testCountry := "YY"
-	testCountryField := "testCountry"
-
-	ts := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintln(w, fmt.Sprintf(
-				`{"%s": "%s"}`, testCountryField, testCountry))
-		}))
-	defer ts.Close()
-
-	conf.Country.URL = ts.URL
-	conf.Country.Field = testCountryField
-
 	env := newWorkerTest(t)
 	fixture := env.newTestFixture(t, data.JobAgentPreOfferingMsgBCPublish,
 		data.JobOffering)
@@ -490,6 +473,10 @@ func TestAgentPreOfferingMsgBCPublish(t *testing.T) {
 	fixture.job.Data = jobDataB
 	env.updateInTestDB(t, fixture.job)
 
+	country := "YY"
+	fixture.Product.Country = &country
+	env.updateInTestDB(t, fixture.Product)
+
 	minDeposit := fixture.Offering.MinUnits*fixture.Offering.UnitPrice +
 		fixture.Offering.SetupPrice
 
@@ -504,9 +491,9 @@ func TestAgentPreOfferingMsgBCPublish(t *testing.T) {
 	offering := &data.Offering{}
 	env.findTo(t, offering, fixture.Offering.ID)
 
-	if offering.Country != testCountry {
+	if offering.Country != *fixture.Product.Country {
 		t.Fatalf("expected: %s, got: %s",
-			testCountry, offering.Country)
+			*fixture.Product.Country, offering.Country)
 	}
 
 	if offering.RawMsg == fixture.Offering.RawMsg {

--- a/proc/worker/errors.go
+++ b/proc/worker/errors.go
@@ -78,7 +78,6 @@ const (
 	ErrOfferingNotActive
 	ErrPopUpOfferingTryAgain
 	ErrOfferingDeposit
-	ErrCountryNotFound
 )
 
 var errMsgs = errors.Messages{
@@ -154,7 +153,6 @@ var errMsgs = errors.Messages{
 	ErrOfferingNotActive:            "offering is inactive",
 	ErrPopUpOfferingTryAgain:        "could not pop up, try again later",
 	ErrOfferingDeposit:              "incorrect offering deposit",
-	ErrCountryNotFound:              "country not found",
 }
 
 func init() {

--- a/proc/worker/misc.go
+++ b/proc/worker/misc.go
@@ -7,8 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
-	"net/http"
-	"strings"
 	"time"
 
 	"github.com/AlekSi/pointer"
@@ -272,60 +270,4 @@ func (w *Worker) saveRecord(logger log.Logger, rec reform.Record) error {
 		return ErrInternal
 	}
 	return nil
-}
-
-func (w *Worker) do(
-	ctx context.Context, req *http.Request) (*http.Response, error) {
-	res, err := http.DefaultClient.Do(req.WithContext(ctx))
-	if err != nil {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
-func (w *Worker) getCountry() (string, error) {
-	logger := w.logger.Add("method", "getCountry")
-
-	ctx, cancel := context.WithTimeout(context.Background(),
-		time.Second*w.countryConfig.Timeout)
-	defer cancel()
-
-	req, err := http.NewRequest(http.MethodGet, w.countryConfig.URL, nil)
-	if err != nil {
-		logger.Error(err.Error())
-		return "", ErrInternal
-	}
-	res, err := w.do(ctx, req)
-	if err != nil {
-		logger.Error(err.Error())
-		return "", ErrInternal
-	}
-	defer res.Body.Close()
-
-	object := make(map[string]interface{})
-	if err := json.NewDecoder(res.Body).Decode(&object); err != nil {
-		logger.Error(err.Error())
-		return "", ErrInternal
-	}
-
-	logger = logger.Add("fields", object)
-
-	field, ok := object[w.countryConfig.Field]
-	if !ok {
-		logger.Error(ErrCountryNotFound.Error())
-		return "", ErrCountryNotFound
-	}
-
-	country, ok := field.(string)
-	if !ok {
-		logger.Error(ErrCountryNotFound.Error())
-		return "", ErrCountryNotFound
-	}
-
-	return strings.TrimSpace(strings.ToUpper(country)), nil
 }

--- a/proc/worker/selectors.go
+++ b/proc/worker/selectors.go
@@ -127,6 +127,16 @@ func (w *Worker) offering(logger log.Logger, pk string) (*data.Offering, error) 
 	return offering, nil
 }
 
+func (w *Worker) productByPK(logger log.Logger, pk string) (*data.Product, error) {
+	product := &data.Product{}
+	err := data.FindByPrimaryKeyTo(w.db.Querier, product, pk)
+	if err != nil {
+		logger.Error(err.Error())
+		return nil, ErrProductNotFound
+	}
+	return product, nil
+}
+
 func (w *Worker) offeringByHash(logger log.Logger,
 	hash common.Hash) (*data.Offering, error) {
 	hashStr := data.FromBytes(hash.Bytes())

--- a/proc/worker/worker.go
+++ b/proc/worker/worker.go
@@ -2,13 +2,13 @@ package worker
 
 import (
 	"strings"
-	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"gopkg.in/reform.v1"
 
 	"github.com/privatix/dappctrl/client/svcrun"
+	"github.com/privatix/dappctrl/country"
 	"github.com/privatix/dappctrl/data"
 	"github.com/privatix/dappctrl/eth"
 	"github.com/privatix/dappctrl/eth/contract"
@@ -43,13 +43,6 @@ type GasConf struct {
 	}
 }
 
-// CountryConfig is the configuration for obtaining a country code.
-type CountryConfig struct {
-	Field   string
-	Timeout time.Duration // in seconds.
-	URL     string
-}
-
 // Worker has all worker routines.
 type Worker struct {
 	abi            abi.ABI
@@ -66,14 +59,15 @@ type Worker struct {
 	processor      *proc.Processor
 	runner         svcrun.ServiceRunner
 	ethConfig      *eth.Config
-	countryConfig  *CountryConfig
+	countryConfig  *country.Config
 }
 
 // NewWorker returns new instance of worker.
 func NewWorker(logger log.Logger, db *reform.DB, somc *somc.Conn,
 	ethBack EthBackend, gasConc *GasConf, pscAddr common.Address,
-	payAddr string, pwdGetter data.PWDGetter, countryConf *CountryConfig,
-	decryptKeyFunc data.ToPrivateKeyFunc, eptConf *ept.Config) (*Worker, error) {
+	payAddr string, pwdGetter data.PWDGetter,
+	countryConf *country.Config, decryptKeyFunc data.ToPrivateKeyFunc,
+	eptConf *ept.Config) (*Worker, error) {
 	abi, err := abi.JSON(
 		strings.NewReader(contract.PrivatixServiceContractABI))
 	if err != nil {
@@ -98,13 +92,6 @@ func NewWorker(logger log.Logger, db *reform.DB, somc *somc.Conn,
 		somc:           somc,
 		countryConfig:  countryConf,
 	}, nil
-}
-
-// NewCountryConfig creates new configuration for obtaining a country code.
-func NewCountryConfig() *CountryConfig {
-	return &CountryConfig{
-		Timeout: 30,
-	}
 }
 
 // SetQueue sets a queue for handlers.

--- a/proc/worker/worker_test.go
+++ b/proc/worker/worker_test.go
@@ -15,6 +15,7 @@ import (
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"gopkg.in/reform.v1"
 
+	"github.com/privatix/dappctrl/country"
 	"github.com/privatix/dappctrl/data"
 	"github.com/privatix/dappctrl/eth"
 	"github.com/privatix/dappctrl/job"
@@ -44,7 +45,7 @@ type testConfig struct {
 	SOMC      *somc.Config
 	SOMCTest  *somc.TestConfig
 	pscAddr   common.Address
-	Country   *CountryConfig
+	Country   *country.Config
 }
 
 func newTestConfig() *testConfig {
@@ -58,7 +59,7 @@ func newTestConfig() *testConfig {
 		SOMC:     somc.NewConfig(),
 		SOMCTest: somc.NewTestConfig(),
 		pscAddr:  common.HexToAddress("0x1"),
-		Country:  NewCountryConfig(),
+		Country:  country.NewConfig(),
 	}
 }
 

--- a/sesssrv/server.go
+++ b/sesssrv/server.go
@@ -5,6 +5,7 @@ import (
 
 	"gopkg.in/reform.v1"
 
+	"github.com/privatix/dappctrl/country"
 	"github.com/privatix/dappctrl/util/log"
 	"github.com/privatix/dappctrl/util/srv"
 )
@@ -24,9 +25,10 @@ func NewConfig() *Config {
 // Server is a service session server.
 type Server struct {
 	*srv.Server
-	conf   *Config
-	db     *reform.DB
-	logger log.Logger
+	conf        *Config
+	countryConf *country.Config
+	db          *reform.DB
+	logger      log.Logger
 }
 
 // Service API paths.
@@ -41,12 +43,14 @@ const (
 )
 
 // NewServer creates a new session server.
-func NewServer(conf *Config, logger log.Logger, db *reform.DB) *Server {
+func NewServer(conf *Config, logger log.Logger, db *reform.DB,
+	countryConf *country.Config) *Server {
 	s := &Server{
-		Server: srv.NewServer(conf.Config),
-		conf:   conf,
-		db:     db,
-		logger: logger.Add("type", "sesssrv.Server"),
+		Server:      srv.NewServer(conf.Config),
+		conf:        conf,
+		db:          db,
+		logger:      logger.Add("type", "sesssrv.Server"),
+		countryConf: countryConf,
 	}
 
 	modifyHandler := func(h srv.HandlerFunc) srv.HandlerFunc {

--- a/svc/dappvpn/msg/config_test.go
+++ b/svc/dappvpn/msg/config_test.go
@@ -82,7 +82,7 @@ func checkCA(t *testing.T, config string, ca []byte) {
 func checkConf(t *testing.T, config string, keys []string) {
 	keys = append(keys, remoteKey)
 
-	result, err := vpnParams(logger2, config, keys)
+	result, err := vpnParams(logger, config, keys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +136,7 @@ func TestMakeFiles(t *testing.T) {
 	accessFile := filepath.Join(rootDir, defaultAccessFile)
 	confFile := filepath.Join(rootDir, clientConfigName)
 
-	if err := MakeFiles(logger2, rootDir, serviceEndpointAddress, username,
+	if err := MakeFiles(logger, rootDir, serviceEndpointAddress, username,
 		password, data, SpecificOptions(
 			conf.VPNMonitor)); err != nil {
 		t.Fatal(err)

--- a/svc/dappvpn/msg/parsing_test.go
+++ b/svc/dappvpn/msg/parsing_test.go
@@ -50,7 +50,7 @@ func TestParsingVpnConfigFile(t *testing.T) {
 
 	createTestFile(t, filepath.Join(dir, configName), parameters)
 
-	result, err := vpnParams(logger2, config, parameterKeys(parameters))
+	result, err := vpnParams(logger, config, parameterKeys(parameters))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/svc/dappvpn/prepare/prepare_test.go
+++ b/svc/dappvpn/prepare/prepare_test.go
@@ -33,9 +33,8 @@ var (
 		VPNMonitor        *mon.Config
 	}
 
-	db      *reform.DB
-	logger  *util.Logger
-	logger2 log.Logger
+	db     *reform.DB
+	logger log.Logger
 )
 
 type testSessSrvConfig struct {
@@ -55,14 +54,12 @@ func TestMain(m *testing.M) {
 
 	util.ReadTestConfig(&conf)
 
-	logger = util.NewTestLogger(conf.Log)
-
 	l, err := log.NewStderrLogger(conf.FileLog)
 	if err != nil {
 		panic(err)
 	}
 
-	logger2 = l
+	logger = l
 
 	db = data.NewTestDB(conf.DB)
 	defer data.CloseDB(db)
@@ -71,7 +68,7 @@ func TestMain(m *testing.M) {
 }
 
 func newTestSessSrv(t *testing.T, timeout time.Duration) *testSessSrv {
-	s := sesssrv.NewServer(conf.SessionServer, logger2, db)
+	s := sesssrv.NewServer(conf.SessionServer, logger, db, nil)
 	go func() {
 		time.Sleep(timeout)
 		if err := s.ListenAndServe(); err != http.ErrServerClosed {
@@ -136,7 +133,7 @@ func TestClientConfig(t *testing.T) {
 	adapterConfig.Monitor = conf.VPNMonitor
 	adapterConfig.FileLog = conf.FileLog
 
-	if err := ClientConfig(logger2, fxt.Channel.ID,
+	if err := ClientConfig(logger, fxt.Channel.ID,
 		adapterConfig); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Changes:
* Move country detection functionality to a new package.
* Add the functional definition of a country for any ip address.
* Check offering country by IP address from endpoint message during ClientPreEndpointMsgSOMCGet job  execution.
* Fill `DB.Offering.Country` from `DB.Product.Country`.
* Fill `DB.Product.Country` during pushing product configuration.

Resolves BV-728.