### PR TITLE
set offering hash at creation to resolve unique contraint error

### DIFF
--- a/data/test.go
+++ b/data/test.go
@@ -24,16 +24,16 @@ import (
 )
 
 // TestEncryptedKey is a key encryption simplified for tests performance.
-func TestEncryptedKey(pkey *ecdsa.PrivateKey, auth string) (string, error) {
-	return FromBytes(crypto.FromECDSA(pkey)) + "AUTH:" + auth, nil
+func TestEncryptedKey(pkey *ecdsa.PrivateKey, _ string) (string, error) {
+	return FromBytes(crypto.FromECDSA(pkey)) + "AUTH:" + TestPassword, nil
 }
 
 // TestToPrivateKey is a key decryption simplified for tests performance.
-func TestToPrivateKey(keyB64, auth string) (*ecdsa.PrivateKey, error) {
+func TestToPrivateKey(keyB64, _ string) (*ecdsa.PrivateKey, error) {
 	split := strings.Split(keyB64, "AUTH:")
 	keyB64 = split[0]
 	authStored := split[1]
-	if auth != authStored {
+	if TestPassword != authStored {
 		return nil, fmt.Errorf("passphrase didn't match")
 	}
 	keyBytes, err := ToBytes(keyB64)

--- a/ui/errors.go
+++ b/ui/errors.go
@@ -12,6 +12,7 @@ const (
 	ErrObjectNotFound
 	ErrAccountNotFound
 	ErrChannelNotFound
+	ErrTemplateNotFound
 	ErrDefailtGasPriceNotFound
 	ErrEmptyPassword
 	ErrMinConfirmationsNotFound
@@ -39,6 +40,7 @@ var errMsgs = errors.Messages{
 	ErrObjectNotFound:           "object not found",
 	ErrAccountNotFound:          "account not found",
 	ErrChannelNotFound:          "channel not found",
+	ErrTemplateNotFound:         "template not found",
 	ErrDefailtGasPriceNotFound:  "default gas price setting not found",
 	ErrEmptyPassword:            "invalid password",
 	ErrMinConfirmationsNotFound: "min confirmations setting not found",

--- a/ui/offering_test.go
+++ b/ui/offering_test.go
@@ -378,14 +378,14 @@ func TestCreateOffering(t *testing.T) {
 	_, err := handler.CreateOffering("wrong-password", offering)
 	assertMatchErr(ui.ErrAccessDenied, err)
 
-	res, err := handler.CreateOffering(data.TestPassword, offering)
-	assertMatchErr(nil, err)
-
-	offering2 := &data.Offering{}
-	err = db.FindByPrimaryKeyTo(offering2, res)
-	assertMatchErr(nil, err)
-
-	data.DeleteFromTestDB(t, db, offering2)
+	for _, item := range []data.Offering{*offering, *offering} {
+		res, err := handler.CreateOffering(data.TestPassword, &item)
+		assertMatchErr(nil, err)
+		offering2 := &data.Offering{}
+		err = db.FindByPrimaryKeyTo(offering2, res)
+		assertMatchErr(nil, err)
+		defer data.DeleteFromTestDB(t, db, offering2)
+	}
 }
 
 func TestUpdateOffering(t *testing.T) {

--- a/uisrv/offering_test.go
+++ b/uisrv/offering_test.go
@@ -61,10 +61,6 @@ func postOffering(t *testing.T, v *data.Offering) *http.Response {
 	return sendOffering(t, v, http.MethodPost)
 }
 
-func putOffering(t *testing.T, v *data.Offering) *http.Response {
-	return sendOffering(t, v, "PUT")
-}
-
 func TestPostOfferingSuccess(t *testing.T) {
 	defer cleanDB(t)
 	setTestUserCredentials(t)
@@ -73,9 +69,11 @@ func TestPostOfferingSuccess(t *testing.T) {
 
 	// Successful offering creation.
 	payload := validOfferingPayload()
-	res := postOffering(t, &payload)
-	if res.StatusCode != http.StatusCreated {
-		t.Errorf("failed to create, response: %d", res.StatusCode)
+	for _, req := range []data.Offering{payload, payload} {
+		res := postOffering(t, &req)
+		if res.StatusCode != http.StatusCreated {
+			t.Errorf("failed to create, response: %d", res.StatusCode)
+		}
 	}
 }
 
@@ -147,23 +145,6 @@ func TestPostOfferingValidation(t *testing.T) {
 		if res.StatusCode != http.StatusBadRequest {
 			t.Errorf("failed with response: %d", res.StatusCode)
 		}
-	}
-}
-
-func TestPutOfferingSuccess(t *testing.T) {
-	defer cleanDB(t)
-	setTestUserCredentials(t)
-
-	createOfferingFixtures(t)
-	testOffering := data.NewTestOffering(testAgent.EthAddr, testProd.ID, testTpl.ID)
-	insertItems(t, testOffering)
-
-	// Successful offering creation.
-	payload := validOfferingPayload()
-	payload.ID = testOffering.ID
-	res := putOffering(t, &payload)
-	if res.StatusCode != http.StatusOK {
-		t.Fatalf("failed to put, response: %d", res.StatusCode)
 	}
 }
 


### PR DESCRIPTION
Agent can't create offering if there is one that has not been published yet. This is because of unique constraint we declare on `offering.hash` field and because we compute has in `AgentPreOfferingMsgBCPublish`. **Solution**: set offering hash at creation.

The other change related to offering update. Right now we don't have this use case, so I deleted related `uisrv` endpoint and `ui` method