### PR TITLE
Clearly register error in log about failed authentication.

### DIFF
--- a/svc/dappvpn/prepare/errors.go
+++ b/svc/dappvpn/prepare/errors.go
@@ -7,13 +7,11 @@ import (
 // Errors.
 const (
 	// CRC16("github.com/privatix/dappctrl/svc/dappvpn/prepare") = 0x23BD
-	ErrGetEndpoint errors.Error = 0x23BD<<8 + iota
-	ErrMakeConfig
+	ErrMakeConfig errors.Error = 0x23BD<<8 + iota
 )
 
 var errMsgs = errors.Messages{
-	ErrGetEndpoint: "failed to get endpoint",
-	ErrMakeConfig:  "failed to make client configuration files",
+	ErrMakeConfig: "failed to make client configuration files",
 }
 
 func init() { errors.InjectMessages(errMsgs) }

--- a/svc/dappvpn/prepare/prepare.go
+++ b/svc/dappvpn/prepare/prepare.go
@@ -23,8 +23,7 @@ func ClientConfig(logger log.Logger, channel string,
 		adapterConfig.Server.Username, adapterConfig.Server.Password,
 		sesssrv.PathEndpointMsg, args, &endpoint)
 	if err != nil {
-		logger.Add("channel", channel).Error(err.Error())
-		return ErrGetEndpoint
+		return err
 	}
 
 	save := func(str *string) string {
@@ -37,12 +36,8 @@ func ClientConfig(logger log.Logger, channel string,
 	target := filepath.Join(
 		adapterConfig.OpenVPN.ConfigRoot, endpoint.Channel)
 
-	err = msg.MakeFiles(logger, target,
+	return msg.MakeFiles(logger, target,
 		save(endpoint.ServiceEndpointAddress), save(endpoint.Username),
 		save(endpoint.Password), endpoint.AdditionalParams,
 		msg.SpecificOptions(adapterConfig.Monitor))
-	if err != nil {
-		return ErrMakeConfig
-	}
-	return nil
 }


### PR DESCRIPTION
If username is wrong in dappvpn.config.json, then will be errors in a log:
Agent:
* `dappctrl`: WARNING access denied map[sender:ip:port type:sesssrv.Server method:RequireBasicAuth]

Client:
* `dappctrl`: WARNING access denied map[type:sesssrv.Server method:RequireBasicAuth sender:ip:port]
* `dappvpn`: FATAL failed to prepare client configuration: server responed with error: access denied (3) map[channel:channel id]

Resolves BV-880.