### PR TITLE
Fix agentPreServiceTerminate.

### DIFF
--- a/proc/worker/agent.go
+++ b/proc/worker/agent.go
@@ -248,6 +248,11 @@ func (w *Worker) AgentPreServiceTerminate(job *data.Job) error {
 	if err != nil {
 		return err
 	}
+
+	if channel.ReceiptBalance == 0 {
+		return nil
+	}
+
 	return w.agentCooperativeClose(logger, job, channel)
 }
 


### PR DESCRIPTION
If `channel.ReceiptBalance` = 0, then no need to call a `PSC.cooperativeClose()`.
Resolves BV-924.