### PR TITLE
Reconnect to Ethereum node after lost connection.

### DIFF
--- a/dappctrl-dev.config.json
+++ b/dappctrl-dev.config.json
@@ -38,6 +38,7 @@
         "Timeout": 1
     },
     "Eth": {
+        "CheckTimeout": 10,
         "Contract": {
             "PTCAddrHex": "0x0d825eb81b996c67a55f7da350b6e73bab3cb0ec",
             "PSCAddrHex": "0x67c3ce713b1c40b2364360d37a15eddbc5aa9420",
@@ -49,7 +50,7 @@
         },
         "GethURL": "https://rinkeby.infura.io/v3/6396832f7ea1488ba30fb4de8f6b06ea",
         "Timeout": 120,
-        "HttpClient": {
+        "HTTPClient": {
             "DialTimeout": 10,
             "TLSHandshakeTimeout": 5,
             "ResponseHeaderTimeout": 60,

--- a/dappctrl.config.json
+++ b/dappctrl.config.json
@@ -38,6 +38,7 @@
         "Timeout": 1
     },
     "Eth": {
+        "CheckTimeout": 20,
         "Contract": {
             "PTCAddrHex": "0x0d825eb81b996c67a55f7da350b6e73bab3cb0ec",
             "PSCAddrHex": "0x182e0724f997ca79f9eb7318fce1752f8d88c736",
@@ -49,7 +50,7 @@
         },
         "GethURL": "https://rinkeby.infura.io/v3/6396832f7ea1488ba30fb4de8f6b06ea",
         "Timeout": 120,
-        "HttpClient": {
+        "HTTPClient": {
             "DialTimeout": 10,
             "TLSHandshakeTimeout": 5,
             "ResponseHeaderTimeout": 60,

--- a/eth/config.go
+++ b/eth/config.go
@@ -9,14 +9,15 @@ type PSCPeriods struct {
 
 // Config is a configuration for Ethereum client.
 type Config struct {
-	Contract struct {
+	CheckTimeout uint64
+	Contract     struct {
 		PTCAddrHex string
 		PSCAddrHex string
 		Periods    *PSCPeriods
 	}
 	GethURL    string
 	Timeout    uint64
-	HttpClient *httpClientConf
+	HTTPClient *httpClientConf
 }
 
 type httpClientConf struct {
@@ -31,8 +32,9 @@ type httpClientConf struct {
 // NewConfig creates a default Ethereum client configuration.
 func NewConfig() *Config {
 	return &Config{
-		Timeout: 10,
-		HttpClient: &httpClientConf{
+		CheckTimeout: 20,
+		Timeout:      10,
+		HTTPClient: &httpClientConf{
 			DialTimeout:           5,
 			TLSHandshakeTimeout:   2,
 			ResponseHeaderTimeout: 8,

--- a/eth/test.go
+++ b/eth/test.go
@@ -1,6 +1,6 @@
 // +build !notest
 
-package adapter
+package eth
 
 import (
 	"context"
@@ -23,7 +23,7 @@ type TestEthBackCall struct {
 	args   []interface{}
 }
 
-// TestEthBackend is mock for EthBackend.
+// TestEthBackend is mock for Backend.
 type TestEthBackend struct {
 	CallStack              []TestEthBackCall
 	BalanceEth             *big.Int
@@ -358,4 +358,26 @@ func (b *TestEthBackend) PSCPopupServiceOffering(opts *bind.TransactOpts,
 		opts.GasPrice, []byte{})
 
 	return tx, nil
+}
+
+// FilterLogs is mock to FilterLogs.
+func (b *TestEthBackend) FilterLogs(ctx context.Context,
+	q ethereum.FilterQuery) ([]types.Log, error) {
+	return nil, nil
+}
+
+// HeaderByNumber is mock to HeaderByNumber.
+func (b *TestEthBackend) HeaderByNumber(ctx context.Context,
+	number *big.Int) (*types.Header, error) {
+	return nil, nil
+}
+
+// PTCAddress is mock to PTCAddress.
+func (b *TestEthBackend) PTCAddress() common.Address {
+	return common.Address{}
+}
+
+// PSCAddress is mock to PSCAddress.
+func (b *TestEthBackend) PSCAddress() common.Address {
+	return b.PscAddr
 }

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/common"
 	"gopkg.in/reform.v1"
 
 	abill "github.com/privatix/dappctrl/agent/bill"
@@ -26,7 +25,6 @@ import (
 	"github.com/privatix/dappctrl/monitor"
 	"github.com/privatix/dappctrl/pay"
 	"github.com/privatix/dappctrl/proc"
-	"github.com/privatix/dappctrl/proc/adapter"
 	"github.com/privatix/dappctrl/proc/handlers"
 	"github.com/privatix/dappctrl/proc/looper"
 	"github.com/privatix/dappctrl/proc/worker"
@@ -175,7 +173,7 @@ func createUIServer(conf *ui.Config, logger log.Logger, db *reform.DB,
 
 func startAutoPopUpLoop(ctx context.Context, cfg *looper.Config, period uint32,
 	logger log.Logger, db *reform.DB, queue job.Queue,
-	ethBack adapter.EthBackend) error {
+	ethBack eth.Backend) error {
 	var timeout time.Duration
 	if cfg.AutoOfferingPopUpTimeout != 0 {
 		timeout = time.Second *
@@ -232,27 +230,6 @@ func main() {
 	defer closer.Close()
 	defer panicHunter(logger)
 
-	ethClient, err := eth.NewClient(context.Background(),
-		conf.Eth, logger)
-	if err != nil {
-		logger.Fatal(err.Error())
-	}
-	defer ethClient.Close()
-
-	ptcAddr := common.HexToAddress(conf.Eth.Contract.PTCAddrHex)
-	ptc, err := contract.NewPrivatixTokenContract(
-		ptcAddr, ethClient.EthClient())
-	if err != nil {
-		logger.Fatal(err.Error())
-	}
-
-	pscAddr := common.HexToAddress(conf.Eth.Contract.PSCAddrHex)
-	psc, err := contract.NewPrivatixServiceContract(
-		pscAddr, ethClient.EthClient())
-	if err != nil {
-		logger.Fatal(err.Error())
-	}
-
 	somcConn, err := somc.NewConn(conf.SOMC, logger)
 	if err != nil {
 		logger.Fatal(err.Error())
@@ -261,13 +238,11 @@ func main() {
 
 	pwdStorage := getPWDStorage(conf)
 
-	ethBack := adapter.NewEthBackend(
-		psc, ptc, ethClient.EthClient(), conf.Eth.Timeout)
+	ethBack := eth.NewBackend(conf.Eth, logger)
 
-	worker, err := worker.NewWorker(logger, db, somcConn,
-		ethBack, conf.Gas, pscAddr, conf.PayAddress,
-		pwdStorage, conf.Country, data.ToPrivateKey, conf.EptMsg,
-		conf.Eth.Contract.Periods)
+	worker, err := worker.NewWorker(logger, db, somcConn, ethBack,
+		conf.Gas, conf.PayAddress, pwdStorage, conf.Country,
+		data.ToPrivateKey, conf.EptMsg, conf.Eth.Contract.Periods)
 	if err != nil {
 		logger.Fatal(err.Error())
 	}
@@ -283,9 +258,8 @@ func main() {
 	defer runner.StopAll()
 	worker.SetRunner(runner)
 
-	mon, err := monitor.NewMonitor(conf.BlockMonitor, ethClient.EthClient(),
-		ethClient.CloseIdleConnections, db, logger, pscAddr, ptcAddr,
-		conf.Role, queue)
+	mon, err := monitor.NewMonitor(conf.BlockMonitor, ethBack, db, logger,
+		ethBack.PSCAddress(), ethBack.PTCAddress(), conf.Role, queue)
 	if err != nil {
 		logger.Fatal(err.Error())
 	}

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 	"time"
 
-	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
-	reform "gopkg.in/reform.v1"
+	"gopkg.in/reform.v1"
 
 	"github.com/privatix/dappctrl/data"
 	"github.com/privatix/dappctrl/eth/contract"
@@ -46,11 +46,10 @@ type Queue interface {
 
 // Monitor is a blockchain monitor.
 type Monitor struct {
-	db                   *reform.DB
-	closeIdleConnections func()
-	eth                  Client
-	logger               log.Logger
-	queue                Queue
+	db     *reform.DB
+	eth    Client
+	logger log.Logger
+	queue  Queue
 
 	ethCallTimeout      time.Duration
 	pscABI              abi.ABI
@@ -62,9 +61,8 @@ type Monitor struct {
 }
 
 // NewMonitor creates new blockchain monitor.
-func NewMonitor(conf *Config, c Client, closeIdleConnections func(),
-	db *reform.DB, l log.Logger, psc, ptc common.Address, role string,
-	q Queue) (*Monitor, error) {
+func NewMonitor(conf *Config, c Client, db *reform.DB, l log.Logger, psc,
+	ptc common.Address, role string, q Queue) (*Monitor, error) {
 	abiJSON := contract.PrivatixServiceContractABI
 	pscABI, err := abi.JSON(strings.NewReader(abiJSON))
 	if err != nil {
@@ -74,15 +72,14 @@ func NewMonitor(conf *Config, c Client, closeIdleConnections func(),
 	ethCallTimeout := time.Duration(conf.EthCallTimeout) * time.Second
 	queryPause := time.Duration(conf.QueryPause) * time.Second
 	m := &Monitor{
-		db:                   db,
-		closeIdleConnections: closeIdleConnections,
-		eth:                  c,
-		logger:               l.Add("type", "monitor.Monitor"),
-		queue:                q,
-		ethCallTimeout:       ethCallTimeout,
-		pscABI:               pscABI,
-		pscAddr:              psc,
-		queryPause:           queryPause,
+		db:             db,
+		eth:            c,
+		logger:         l.Add("type", "monitor.Monitor"),
+		queue:          q,
+		ethCallTimeout: ethCallTimeout,
+		pscABI:         pscABI,
+		pscAddr:        psc,
+		queryPause:     queryPause,
 	}
 
 	f := m.clientQueries
@@ -117,11 +114,6 @@ func (m *Monitor) Start() {
 					m.getFilterLogQueries, m.jobsProducers)
 				if err != nil {
 					logger.Error(err.Error())
-				}
-				if (err == ErrFailedToGetHeaderByNumber ||
-					err == ErrFailedToFetchLogs) &&
-					m.closeIdleConnections != nil {
-					m.closeIdleConnections()
 				}
 			}
 		}

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"testing"
 
-	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
-	reform "gopkg.in/reform.v1"
+	"gopkg.in/reform.v1"
 
 	"github.com/privatix/dappctrl/data"
 	"github.com/privatix/dappctrl/eth/contract"
@@ -113,9 +113,8 @@ func TestMain(m *testing.M) {
 	ethClient = &testEthereumClient{}
 	queue := job.NewQueue(conf.Job, logger, db, nil)
 	pscAddr = common.HexToAddress("0x1")
-	mon, err = monitor.NewMonitor(&monitor.Config{}, ethClient, nil, db,
-		logger, pscAddr, common.HexToAddress("0x2"), data.RoleAgent,
-		queue)
+	mon, err = monitor.NewMonitor(&monitor.Config{}, ethClient, db, logger,
+		pscAddr, common.HexToAddress("0x2"), data.RoleAgent, queue)
 	if err != nil {
 		panic(err)
 	}

--- a/proc/looper/loop_test.go
+++ b/proc/looper/loop_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/privatix/dappctrl/eth"
 	"github.com/privatix/dappctrl/eth/contract"
 	"github.com/privatix/dappctrl/job"
-	"github.com/privatix/dappctrl/proc/adapter"
 	"github.com/privatix/dappctrl/util"
 	"github.com/privatix/dappctrl/util/log"
 )
@@ -30,7 +29,7 @@ var (
 	logger             log.Logger
 	db                 *reform.DB
 	serviceContractABI abi.ABI
-	ethBackend         *adapter.TestEthBackend
+	ethBackend         *eth.TestEthBackend
 )
 
 func createJob() *data.Job {
@@ -123,7 +122,7 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	ethBackend = adapter.NewTestEthBackend(common.HexToAddress("0x1"))
+	ethBackend = eth.NewTestEthBackend(common.HexToAddress("0x1"))
 
 	os.Exit(m.Run())
 }

--- a/proc/looper/offering.go
+++ b/proc/looper/offering.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/reform.v1"
 
 	"github.com/privatix/dappctrl/data"
-	"github.com/privatix/dappctrl/proc/adapter"
+	"github.com/privatix/dappctrl/eth"
 	"github.com/privatix/dappctrl/util/log"
 )
 
@@ -23,7 +23,7 @@ import (
 // pop up all offerings, then no one of them is popped up. Function calculates
 // the pop up time.
 func AutoOfferingPopUp(logger log.Logger, abi abi.ABI, db *reform.DB,
-	ethBack adapter.EthBackend, timeNowFunc func() time.Time,
+	ethBack eth.Backend, timeNowFunc func() time.Time,
 	period uint32) []*data.Job {
 	logger = logger.Add("method", "AutoOfferingPopUp")
 
@@ -47,7 +47,7 @@ func AutoOfferingPopUp(logger log.Logger, abi abi.ABI, db *reform.DB,
 }
 
 func calcDelayToOfferingPopUp(offeringHash common.Hash,
-	ethBack adapter.EthBackend, popUpPeriod uint32,
+	ethBack eth.Backend, popUpPeriod uint32,
 	lastBlock *big.Int) (delay time.Duration, err error) {
 	_, _, _, _, lastUpdateBlock, _, err :=
 		ethBack.PSCGetOfferingInfo(&bind.CallOpts{}, offeringHash)
@@ -65,7 +65,7 @@ func calcDelayToOfferingPopUp(offeringHash common.Hash,
 	return delay, err
 }
 
-func calcPriceToOfferingPopUp(abi abi.ABI, ethBack adapter.EthBackend,
+func calcPriceToOfferingPopUp(abi abi.ABI, ethBack eth.Backend,
 	gasPrice *big.Int) *big.Int {
 	input, err := abi.Pack("popupServiceOffering", common.Hash{})
 	if err != nil {
@@ -85,7 +85,7 @@ func calcPriceToOfferingPopUp(abi abi.ABI, ethBack adapter.EthBackend,
 }
 
 func agentHaveEnoughMoney(logger log.Logger, agent common.Address,
-	price *big.Int, ethBack adapter.EthBackend) bool {
+	price *big.Int, ethBack eth.Backend) bool {
 	balance, err := ethBack.EthBalanceAt(context.Background(), agent)
 	if err != nil {
 		logger.Error(err.Error())
@@ -122,7 +122,7 @@ func findOfferingsToPopUp(logger log.Logger, db *reform.DB) []reform.Struct {
 }
 
 func autoOfferingPopUp(logger log.Logger, abi abi.ABI, db *reform.DB,
-	ethBack adapter.EthBackend, timeNowFunc func() time.Time,
+	ethBack eth.Backend, timeNowFunc func() time.Time,
 	period uint32) []*data.Job {
 	offerings := findOfferingsToPopUp(logger, db)
 	if len(offerings) == 0 {

--- a/proc/worker/client_test.go
+++ b/proc/worker/client_test.go
@@ -15,11 +15,11 @@ import (
 	"github.com/privatix/dappctrl/client/svcrun"
 	"github.com/privatix/dappctrl/country"
 	"github.com/privatix/dappctrl/data"
+	"github.com/privatix/dappctrl/eth"
 	"github.com/privatix/dappctrl/messages"
 	"github.com/privatix/dappctrl/messages/ept"
 	"github.com/privatix/dappctrl/messages/offer"
 	"github.com/privatix/dappctrl/proc"
-	"github.com/privatix/dappctrl/proc/adapter"
 	"github.com/privatix/dappctrl/util"
 )
 
@@ -89,9 +89,9 @@ func TestClientPreChannelCreate(t *testing.T) {
 		tx.Issued.Before(issued) || tx.Issued.After(time.Now()) ||
 		tx.AddrFrom != fxt.Account.EthAddr ||
 		tx.AddrTo != fxt.Offering.Agent ||
-		tx.Nonce == nil || *tx.Nonce != fmt.Sprint(adapter.TestTXNonce) ||
-		tx.GasPrice != uint64(adapter.TestTXGasPrice) ||
-		tx.Gas != uint64(adapter.TestTXGasLimit) ||
+		tx.Nonce == nil || *tx.Nonce != fmt.Sprint(eth.TestTXNonce) ||
+		tx.GasPrice != uint64(eth.TestTXGasPrice) ||
+		tx.Gas != uint64(eth.TestTXGasLimit) ||
 		tx.RelatedType != data.JobChannel {
 		t.Fatalf("wrong transaction content")
 	}
@@ -297,7 +297,7 @@ func TestClientPreChannelTopUp(t *testing.T) {
 	defer fxt.close()
 
 	setJobData(t, fxt.DB, fxt.job, data.JobPublishData{
-		GasPrice: uint64(adapter.TestTXGasPrice),
+		GasPrice: uint64(eth.TestTXGasPrice),
 	})
 
 	minDeposit := fxt.Offering.UnitPrice*fxt.Offering.MinUnits +
@@ -322,9 +322,9 @@ func TestClientPreChannelTopUp(t *testing.T) {
 		tx.Issued.Before(issued) || tx.Issued.After(time.Now()) ||
 		tx.AddrFrom != fxt.UserAcc.EthAddr ||
 		tx.AddrTo != data.HexFromBytes(env.worker.pscAddr.Bytes()) ||
-		tx.Nonce == nil || *tx.Nonce != fmt.Sprint(adapter.TestTXNonce) ||
-		tx.GasPrice != uint64(adapter.TestTXGasPrice) ||
-		tx.Gas != uint64(adapter.TestTXGasLimit) ||
+		tx.Nonce == nil || *tx.Nonce != fmt.Sprint(eth.TestTXNonce) ||
+		tx.GasPrice != uint64(eth.TestTXGasPrice) ||
+		tx.Gas != uint64(eth.TestTXGasLimit) ||
 		tx.RelatedType != data.JobChannel ||
 		tx.RelatedID != fxt.Channel.ID {
 		t.Fatalf("wrong transaction content")
@@ -361,7 +361,7 @@ func TestClientPreUncooperativeCloseRequest(t *testing.T) {
 	issued := time.Now()
 
 	setJobData(t, fxt.DB, fxt.job, data.JobPublishData{
-		GasPrice: uint64(adapter.TestTXGasPrice),
+		GasPrice: uint64(eth.TestTXGasPrice),
 	})
 
 	runJob(t, env.worker.ClientPreUncooperativeCloseRequest, fxt.job)
@@ -380,9 +380,9 @@ func TestClientPreUncooperativeCloseRequest(t *testing.T) {
 		tx.Issued.Before(issued) || tx.Issued.After(time.Now()) ||
 		tx.AddrFrom != fxt.Channel.Client ||
 		tx.AddrTo != data.HexFromBytes(env.worker.pscAddr.Bytes()) ||
-		tx.Nonce == nil || *tx.Nonce != fmt.Sprint(adapter.TestTXNonce) ||
-		tx.GasPrice != uint64(adapter.TestTXGasPrice) ||
-		tx.Gas != uint64(adapter.TestTXGasLimit) ||
+		tx.Nonce == nil || *tx.Nonce != fmt.Sprint(eth.TestTXNonce) ||
+		tx.GasPrice != uint64(eth.TestTXGasPrice) ||
+		tx.Gas != uint64(eth.TestTXGasLimit) ||
 		tx.RelatedType != data.JobChannel ||
 		tx.RelatedID != fxt.Channel.ID {
 		t.Fatalf("wrong transaction content")
@@ -486,9 +486,9 @@ func TestClientPreUncooperativeClose(t *testing.T) {
 		tx.Issued.Before(issued) || tx.Issued.After(time.Now()) ||
 		tx.AddrFrom != fxt.UserAcc.EthAddr ||
 		tx.AddrTo != data.HexFromBytes(env.worker.pscAddr.Bytes()) ||
-		tx.Nonce == nil || *tx.Nonce != fmt.Sprint(adapter.TestTXNonce) ||
-		tx.GasPrice != uint64(adapter.TestTXGasPrice) ||
-		tx.Gas != uint64(adapter.TestTXGasLimit) ||
+		tx.Nonce == nil || *tx.Nonce != fmt.Sprint(eth.TestTXNonce) ||
+		tx.GasPrice != uint64(eth.TestTXGasPrice) ||
+		tx.Gas != uint64(eth.TestTXGasLimit) ||
 		tx.RelatedType != data.JobChannel ||
 		tx.RelatedID != fxt.Channel.ID {
 		t.Fatalf("wrong transaction content")

--- a/proc/worker/worker.go
+++ b/proc/worker/worker.go
@@ -15,7 +15,6 @@ import (
 	"github.com/privatix/dappctrl/job"
 	"github.com/privatix/dappctrl/messages/ept"
 	"github.com/privatix/dappctrl/proc"
-	"github.com/privatix/dappctrl/proc/adapter"
 	"github.com/privatix/dappctrl/somc"
 	"github.com/privatix/dappctrl/util/log"
 )
@@ -51,7 +50,7 @@ type Worker struct {
 	db             *reform.DB
 	decryptKeyFunc data.ToPrivateKeyFunc
 	ept            *ept.Service
-	ethBack        adapter.EthBackend
+	ethBack        eth.Backend
 	gasConf        *GasConf
 	pscAddr        common.Address
 	pwdGetter      data.PWDGetter
@@ -66,10 +65,10 @@ type Worker struct {
 
 // NewWorker returns new instance of worker.
 func NewWorker(logger log.Logger, db *reform.DB, somc *somc.Conn,
-	ethBack adapter.EthBackend, gasConc *GasConf, pscAddr common.Address,
-	payAddr string, pwdGetter data.PWDGetter,
-	countryConf *country.Config, decryptKeyFunc data.ToPrivateKeyFunc,
-	eptConf *ept.Config, pscPeriods *eth.PSCPeriods) (*Worker, error) {
+	ethBack eth.Backend, gasConc *GasConf, payAddr string,
+	pwdGetter data.PWDGetter, countryConf *country.Config,
+	decryptKeyFunc data.ToPrivateKeyFunc, eptConf *ept.Config,
+	pscPeriods *eth.PSCPeriods) (*Worker, error) {
 	abi, err := abi.JSON(
 		strings.NewReader(contract.PrivatixServiceContractABI))
 	if err != nil {
@@ -89,7 +88,7 @@ func NewWorker(logger log.Logger, db *reform.DB, somc *somc.Conn,
 		gasConf:        gasConc,
 		ept:            eptService,
 		ethBack:        ethBack,
-		pscAddr:        pscAddr,
+		pscAddr:        ethBack.PSCAddress(),
 		pwdGetter:      pwdGetter,
 		somc:           somc,
 		countryConfig:  countryConf,

--- a/proc/worker/worker_test.go
+++ b/proc/worker/worker_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/privatix/dappctrl/messages/offer"
 	"github.com/privatix/dappctrl/pay"
 	"github.com/privatix/dappctrl/proc"
-	"github.com/privatix/dappctrl/proc/adapter"
 	"github.com/privatix/dappctrl/somc"
 	"github.com/privatix/dappctrl/util"
 	"github.com/privatix/dappctrl/util/log"
@@ -66,7 +65,7 @@ func newTestConfig() *testConfig {
 
 type workerTest struct {
 	db       *reform.DB
-	ethBack  *adapter.TestEthBackend
+	ethBack  *eth.TestEthBackend
 	fakeSOMC *somc.FakeSOMC
 	somcConn *somc.Conn
 	worker   *Worker
@@ -91,15 +90,14 @@ func newWorkerTest(t *testing.T) *workerTest {
 
 	jobQueue := job.NewQueue(conf.Job, logger, db, nil)
 
-	ethBack := adapter.NewTestEthBackend(conf.pscAddr)
+	ethBack := eth.NewTestEthBackend(conf.pscAddr)
 
 	pwdStorage := new(data.PWDStorage)
 	pwdStorage.Set(data.TestPassword)
 
 	worker, err := NewWorker(logger, db, somcConn, ethBack,
-		conf.Gas, conf.pscAddr, conf.PayServer.Addr, pwdStorage,
-		conf.Country, data.TestToPrivateKey, conf.EptMsg,
-		conf.Eth.Contract.Periods)
+		conf.Gas, conf.PayServer.Addr, pwdStorage, conf.Country,
+		data.TestToPrivateKey, conf.EptMsg, conf.Eth.Contract.Periods)
 	if err != nil {
 		somcConn.Close()
 		fakeSOMC.Close()
@@ -228,7 +226,7 @@ func (e *workerTest) newTestFixture(t *testing.T,
 	e.insertToTestDB(t, job)
 
 	// Clear call stack.
-	e.ethBack.CallStack = []adapter.TestEthBackCall{}
+	e.ethBack.CallStack = []eth.TestEthBackCall{}
 
 	return &workerTestFixture{f, job}
 }


### PR DESCRIPTION
Changes:

- Move Ethereum backend from `github.com/privatix/dappctrl/proc/adapter` to `github.com/privatix/dappctrl/eth`
- Ethereum backend exclusively owns a Ethereum connection.
- Reconnect mechanism to Ethereum.

Resolves BV-892.
