### PR TITLE
Field `offering.max_inactive_time_sec` is not null.

### DIFF
--- a/agent/bill/inactive_test.go
+++ b/agent/bill/inactive_test.go
@@ -22,14 +22,12 @@ func genChannelsForInactivity(t *testing.T) *testFixture {
 	offering1 := data.NewTestOffering(fixture.agent.EthAddr,
 		fixture.product.ID, fixture.template.ID)
 
-	offering1.MaxInactiveTimeSec =
-		&conf.BillingTest.Offer.MaxInactiveTimeSec
+	offering1.MaxInactiveTimeSec = conf.BillingTest.Offer.MaxInactiveTimeSec
 
 	offering2 := data.NewTestOffering(fixture.agent.EthAddr,
 		fixture.product.ID, fixture.template.ID)
 
-	offering2.MaxInactiveTimeSec =
-		&conf.BillingTest.Offer.MaxInactiveTimeSec
+	offering2.MaxInactiveTimeSec = conf.BillingTest.Offer.MaxInactiveTimeSec
 
 	channel1 := data.NewTestChannel(fixture.agent.EthAddr,
 		fixture.client.EthAddr, offering1.ID, 0,

--- a/client/bill/monitor.go
+++ b/client/bill/monitor.go
@@ -215,9 +215,6 @@ func (m *Monitor) isToBeTerminated(
 
 func (m *Monitor) maxInactiveTimeReached(
 	ch *data.Channel, offer *data.Offering) (bool, error) {
-	if offer.MaxInactiveTimeSec == nil {
-		return false, nil
-	}
 	query := fmt.Sprintf("SELECT COUNT(*), MAX(last_usage_time) FROM sessions WHERE sessions.channel = %s", m.db.Placeholder(1))
 	var qty uint
 	var lastUsageNullable pq.NullTime
@@ -230,7 +227,7 @@ func (m *Monitor) maxInactiveTimeReached(
 		lastUsage = ch.PreparedAt
 	}
 	inactiveSeconds := uint64(time.Since(lastUsage).Seconds())
-	return qty > 0 && inactiveSeconds > *offer.MaxInactiveTimeSec, nil
+	return qty > 0 && inactiveSeconds > offer.MaxInactiveTimeSec, nil
 }
 
 func (m *Monitor) postCheque(ch string, amount uint64) {

--- a/client/bill/monitor_test.go
+++ b/client/bill/monitor_test.go
@@ -111,7 +111,7 @@ func TestTerminateInactiveChannel(t *testing.T) {
 
 	fxt.Channel.TotalDeposit = 10
 	oneSec := uint64(1)
-	fxt.Offering.MaxInactiveTimeSec = &oneSec
+	fxt.Offering.MaxInactiveTimeSec = oneSec
 	session := data.NewTestSession(fxt.Channel.ID)
 	// Fake session stopped a day ago.
 	stopped := time.Now().AddDate(0, 0, -1)
@@ -183,12 +183,14 @@ func TestPayment(t *testing.T) {
 	fxt.Offering.UnitPrice = 1
 	fxt.Offering.SetupPrice = 2
 	fxt.Offering.BillingInterval = 2
+	fxt.Offering.MaxInactiveTimeSec = 1000
 
 	fxt.Channel.TotalDeposit = 10
 	fxt.Channel.ReceiptBalance = 4
 
 	sess := data.NewTestSession(fxt.Channel.ID)
 	sess.UnitsUsed = 4
+	sess.LastUsageTime = time.Now()
 
 	data.SaveToTestDB(t, db, fxt.Offering, fxt.Channel, sess)
 	defer data.DeleteFromTestDB(t, db, sess)

--- a/data/migration/scripts/00001_schema_up.sql
+++ b/data/migration/scripts/00001_schema_up.sql
@@ -219,7 +219,7 @@ CREATE TABLE offerings (
     max_suspended_time int NOT NULL -- maximum time in suspend state, after which service will be terminated (in seconds)
         CONSTRAINT positive_max_suspended_time CHECK (offerings.max_suspended_time >= 0),
 
-    max_inactive_time_sec bigint -- maximum inactive time before channel will be closed
+    max_inactive_time_sec bigint NOT NULL -- maximum inactive time before channel will be closed
         CONSTRAINT positive_max_inactive_time_sec CHECK (offerings.max_inactive_time_sec > 0),
 
     free_units smallint NOT NULL DEFAULT 0 -- free units (test, bonus)

--- a/data/schema.go
+++ b/data/schema.go
@@ -137,7 +137,7 @@ type Offering struct {
 	BillingInterval    uint            `json:"billingInterval" reform:"billing_interval" validate:"required"` // Every unit number to be paid.
 	MaxBillingUnitLag  uint            `json:"maxBillingUnitLag" reform:"max_billing_unit_lag"`               // Max maximum tolerance for payment lag.
 	MaxSuspendTime     uint            `json:"maxSuspendTime" reform:"max_suspended_time"`                    // In seconds.
-	MaxInactiveTimeSec *uint64         `json:"maxInactiveTimeSec" reform:"max_inactive_time_sec"`
+	MaxInactiveTimeSec uint64          `json:"maxInactiveTimeSec" reform:"max_inactive_time_sec"`
 	FreeUnits          uint8           `json:"freeUnits" reform:"free_units"`
 	AdditionalParams   json.RawMessage `json:"additionalParams" reform:"additional_params" validate:"required"`
 	AutoPopUp          *bool           `json:"autoPopUp" reform:"auto_pop_up"`

--- a/data/test.go
+++ b/data/test.go
@@ -193,6 +193,7 @@ func NewTestOffering(agent HexString, product, tpl string) *Offering {
 		AdditionalParams:   []byte("{}"),
 		SetupPrice:         11,
 		UnitPrice:          22,
+		MaxInactiveTimeSec: 1,
 	}
 	return offering
 }

--- a/messages/offer/types.go
+++ b/messages/offer/types.go
@@ -18,7 +18,7 @@ type Message struct {
 	BillingInterval           uint              `json:"billingInterval"`
 	MaxBillingUnitLag         uint              `json:"maxBillingUnitLag"`
 	MaxSuspendTime            uint              `json:"maxSuspendTime"`
-	MaxInactiveTimeSec        *uint64           `json:"maxInactiveTimeSec"`
+	MaxInactiveTimeSec        uint64            `json:"maxInactiveTimeSec"`
 	FreeUnits                 uint8             `json:"freeUnits"`
 	Nonce                     string            `json:"nonce"`
 	ServiceSpecificParameters []byte            `json:"serviceSpecificParameters"`

--- a/proc/worker/agent_test.go
+++ b/proc/worker/agent_test.go
@@ -588,7 +588,18 @@ func TestAgentPreOfferingMsgSOMCPublish(t *testing.T) {
 		if ret.Data != offering.RawMsg {
 			t.Fatal("wrong offering published")
 		}
-		if ret.Hash != offering.Hash {
+
+		inHash, err := data.ToBytes(ret.Hash)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		hash, err := data.HexToBytes(offering.Hash)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(inHash, hash) {
 			t.Fatal("wrong hash stored")
 		}
 	case <-time.After(conf.JobHandlerTest.SOMCTimeout * time.Second):

--- a/ui/channel.go
+++ b/ui/channel.go
@@ -244,9 +244,7 @@ func createChanStatusBlock(channel *data.Channel,
 		result.LastChanged = pointer.ToString(
 			util.SingleTimeFormat(*channel.ServiceChangedTime))
 	}
-	if offering.MaxInactiveTimeSec != nil {
-		result.MaxInactiveTime = *offering.MaxInactiveTimeSec
-	}
+	result.MaxInactiveTime = offering.MaxInactiveTimeSec
 
 	return result
 }

--- a/ui/channel_test.go
+++ b/ui/channel_test.go
@@ -219,7 +219,7 @@ func createClientTestData(t *testing.T, fxt *fixture) (close func()) {
 	offering := data.NewTestOffering(fxt.User.EthAddr,
 		fxt.Product.ID, fxt.TemplateOffer.ID)
 	offering.UnitType = data.UnitScalar
-	offering.MaxInactiveTimeSec = pointer.ToUint64(1800)
+	offering.MaxInactiveTimeSec = 1800
 
 	channel := data.NewTestChannel(data.NewTestAccount("").EthAddr,
 		fxt.Account.EthAddr, offering.ID, 0, 10000, data.ChannelActive)
@@ -350,9 +350,9 @@ func checkClientChannelStatus(t *testing.T, resp *ui.ClientChannelInfo,
 			*resp.ChStat.LastChanged)
 	}
 
-	if offer.MaxInactiveTimeSec == nil ||
-		*offer.MaxInactiveTimeSec != resp.ChStat.MaxInactiveTime {
-		t.Fatal("invalid maxInactiveTime field")
+	if offer.MaxInactiveTimeSec != resp.ChStat.MaxInactiveTime {
+		t.Fatalf("expected %d, got: %d", offer.MaxInactiveTimeSec,
+			resp.ChStat.MaxInactiveTime)
 	}
 }
 

--- a/uisrv/channel.go
+++ b/uisrv/channel.go
@@ -447,12 +447,6 @@ func (s *Server) handleGetClientChannelStatus(w http.ResponseWriter,
 
 	resp := new(chanStatusBlock)
 
-	if offer.MaxInactiveTimeSec == nil {
-		offer.MaxInactiveTimeSec = new(uint64)
-	} else {
-		resp.MaxInactiveTime = *offer.MaxInactiveTimeSec
-	}
-
 	if channel.ServiceChangedTime == nil {
 		resp.LastChanged = new(string)
 	} else {
@@ -461,7 +455,7 @@ func (s *Server) handleGetClientChannelStatus(w http.ResponseWriter,
 	}
 	resp.ChannelStatus = channel.ChannelStatus
 	resp.ServiceStatus = channel.ServiceStatus
-	resp.MaxInactiveTime = *offer.MaxInactiveTimeSec
+	resp.MaxInactiveTime = offer.MaxInactiveTimeSec
 
 	s.reply(logger, w, &resp)
 }

--- a/uisrv/channel_test.go
+++ b/uisrv/channel_test.go
@@ -133,9 +133,9 @@ func checkCliChanStatus(t *testing.T, resp chanStatusBlock,
 			expectedTime, *resp.LastChanged)
 	}
 
-	if offer.MaxInactiveTimeSec == nil ||
-		*offer.MaxInactiveTimeSec != resp.MaxInactiveTime {
-		t.Fatal(errFieldVal)
+	if offer.MaxInactiveTimeSec != resp.MaxInactiveTime {
+		t.Fatalf("expected %d, got: %d",
+			offer.MaxInactiveTimeSec, resp.MaxInactiveTime)
 	}
 }
 

--- a/uisrv/offering_test.go
+++ b/uisrv/offering_test.go
@@ -38,7 +38,7 @@ func validOfferingPayload() data.Offering {
 		Description:        nil,
 		FreeUnits:          0,
 		MaxBillingUnitLag:  100,
-		MaxInactiveTimeSec: nil,
+		MaxInactiveTimeSec: 1800,
 		MaxSuspendTime:     1000,
 		MaxUnit:            nil,
 		MinUnits:           uint64(50),

--- a/uisrv/server_test.go
+++ b/uisrv/server_test.go
@@ -85,7 +85,7 @@ func createTestChannel(t *testing.T) *data.Channel {
 	product := data.NewTestProduct()
 	tplOffer := data.NewTestTemplate(data.TemplateOffer)
 	offering := data.NewTestOffering(agent.EthAddr, product.ID, tplOffer.ID)
-	offering.MaxInactiveTimeSec = pointer.ToUint64(10)
+	offering.MaxInactiveTimeSec = 10
 	offering.UnitName = "megabytes"
 	offering.UnitType = data.UnitScalar
 	offering.SetupPrice = 22


### PR DESCRIPTION
Resolves BV-986.