### PR TITLE
add tor setting

### DIFF
--- a/data/prod_data.sql
+++ b/data/prod_data.sql
@@ -78,4 +78,11 @@ VALUES ('offering.autopopup',
         'Allow offerings to pop up automatically.',
         'offering autopopup');
 
+INSERT INTO settings (key, value, permissions, description, name)
+VALUES ('somc.transport.tor',
+        'false',
+        2,
+        'Whether to use Tor as service offering messaging protocol or not',
+        'use Tor');
+
 END TRANSACTION;

--- a/data/settings.go
+++ b/data/settings.go
@@ -18,6 +18,7 @@ const (
 	SettingMinConfirmations   = "eth.min.confirmations"
 	SettingPasswordHash       = "system.password"
 	SettingPasswordSalt       = "system.salt"
+	SettingSOMCUseTor         = "somc.transport.tor"
 )
 
 // ReadSetting reads value of a given setting.

--- a/proc/worker/agent.go
+++ b/proc/worker/agent.go
@@ -481,7 +481,12 @@ func (w *Worker) AgentPreEndpointMsgCreate(job *data.Job) error {
 		return ErrInternal
 	}
 
-	if w.somcType == data.OfferingSOMCShared {
+	offering, err := w.offering(logger, channel.Offering)
+	if err != nil {
+		return err
+	}
+
+	if offering.SOMCType == data.OfferingSOMCShared {
 		if err := w.addJob(logger, tx, data.JobAgentPreEndpointMsgSOMCPublish,
 			data.JobEndpoint, newEndpoint.ID); err != nil {
 			tx.Rollback()
@@ -641,10 +646,22 @@ func (w *Worker) AgentPreOfferingMsgBCPublish(job *data.Job) error {
 	auth.GasLimit = w.gasConf.PSC.RegisterServiceOffering
 	auth.GasPrice = new(big.Int).SetUint64(publishData.GasPrice)
 
+	offering.SOMCType = data.OfferingSOMCShared
+	offering.SOMCData = ""
+
+	useTor, err := data.ReadBoolSetting(w.db.Querier, data.SettingSOMCUseTor)
+	if err != nil {
+		logger.Error(err.Error())
+		return ErrInternal
+	}
+	if useTor {
+		offering.SOMCType = data.OfferingSOMCTor
+		offering.SOMCData = w.torHostName
+	}
 	tx, err := w.ethBack.RegisterServiceOffering(auth,
 		[common.HashLength]byte(common.BytesToHash(offeringHash)),
 		new(big.Int).SetUint64(minDeposit), offering.Supply,
-		w.somcType, w.somcData)
+		offering.SOMCType, offering.SOMCData)
 	if err != nil {
 		logger.Add("GasLimit", auth.GasLimit,
 			"GasPrice", auth.GasPrice).Error(err.Error())
@@ -681,7 +698,17 @@ func (w *Worker) AgentAfterOfferingMsgBCPublish(job *data.Job) error {
 		return ErrInternal
 	}
 
-	if w.somcType == data.OfferingSOMCShared {
+	ethlog, err := w.ethLog(logger, job)
+	if err != nil {
+		return err
+	}
+
+	logInput, err := extractLogOfferingCreated(logger, ethlog)
+	if err != nil {
+		return err
+	}
+
+	if logInput.somcType == data.OfferingSOMCShared {
 		return w.addJob(logger, nil, data.JobAgentPreOfferingMsgSOMCPublish,
 			data.JobOffering, offering.ID)
 	}
@@ -918,8 +945,21 @@ func (w *Worker) AgentPreOfferingPopUp(job *data.Job) error {
 	auth.GasLimit = w.gasConf.PSC.PopupServiceOffering
 	auth.GasPrice = new(big.Int).SetUint64(jobDate.GasPrice)
 
+	useTor, err := data.ReadBoolSetting(w.db.Querier, data.SettingSOMCUseTor)
+	if err != nil {
+		logger.Error(err.Error())
+		return ErrInternal
+	}
+	if useTor {
+		offering.SOMCType = data.OfferingSOMCTor
+		offering.SOMCData = w.torHostName
+	} else {
+		offering.SOMCType = data.OfferingSOMCShared
+		offering.SOMCData = ""
+	}
+
 	tx, err := w.ethBack.PSCPopupServiceOffering(auth, offeringHash,
-		w.somcType, w.somcData)
+		offering.SOMCType, offering.SOMCData)
 	if err != nil {
 		logger.Add("GasLimit", auth.GasLimit,
 			"GasPrice", auth.GasPrice).Error(err.Error())

--- a/proc/worker/agent_test.go
+++ b/proc/worker/agent_test.go
@@ -472,6 +472,14 @@ func TestAgentPreOfferingMsgBCPublish(t *testing.T) {
 	defer env.close()
 	defer fixture.close()
 
+	useTorSetting := &data.Setting{
+		Key:   data.SettingSOMCUseTor,
+		Value: "false",
+		Name:  "tor",
+	}
+	env.insertToTestDB(t, useTorSetting)
+	defer env.deleteFromTestDB(t, useTorSetting)
+
 	// Test ethTx was recorder.
 	defer env.deleteEthTx(t, fixture.job.ID)
 
@@ -512,7 +520,7 @@ func TestAgentPreOfferingMsgBCPublish(t *testing.T) {
 		env.gasConf.PSC.RegisterServiceOffering,
 		[common.HashLength]byte(offeringHash),
 		new(big.Int).SetUint64(minDeposit), offering.Supply,
-		env.worker.somcType, env.worker.somcData)
+		data.OfferingSOMCShared, data.Base64String(""))
 
 	offering = &data.Offering{}
 	env.findTo(t, offering, fixture.Offering.ID)
@@ -537,6 +545,32 @@ func TestAgentAfterOfferingMsgBCPublish(t *testing.T) {
 		data.JobOffering)
 	defer env.close()
 	defer fixture.close()
+
+	logData, err := logOfferingCreatedDataArguments.Pack(uint16(1),
+		data.OfferingSOMCShared, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	setJobData(t, env.db, fixture.job, &data.JobData{
+		EthLog: &data.JobEthLog{
+			Data: logData,
+			Topics: data.LogTopics{
+				common.BytesToHash([]byte{}),
+				common.BytesToHash([]byte{}),
+				common.BytesToHash([]byte{}),
+				common.BytesToHash([]byte{}),
+			},
+		},
+	})
+
+	useTorSetting := &data.Setting{
+		Key:   data.SettingSOMCUseTor,
+		Value: "false",
+		Name:  "tor",
+	}
+	env.insertToTestDB(t, useTorSetting)
+	defer env.deleteFromTestDB(t, useTorSetting)
 
 	runJob(t, env.worker.AgentAfterOfferingMsgBCPublish, fixture.job)
 
@@ -687,13 +721,18 @@ func TestAgentPreOfferingPopUp(t *testing.T) {
 	env := newWorkerTest(t)
 	defer env.close()
 
-	fxt := env.newTestFixture(t,
-		data.JobAgentPreOfferingPopUp, data.JobOffering)
+	fxt := env.newTestFixture(t, data.JobAgentPreOfferingPopUp, data.JobOffering)
 	defer fxt.close()
 
-	setJobData(t, env.db, fxt.job, &data.JobPublishData{
-		GasPrice: 123,
-	})
+	useTorSetting := &data.Setting{
+		Key:   data.SettingSOMCUseTor,
+		Value: "false",
+		Name:  "tor",
+	}
+	env.insertToTestDB(t, useTorSetting)
+	defer env.deleteFromTestDB(t, useTorSetting)
+
+	setJobData(t, env.db, fxt.job, &data.JobPublishData{GasPrice: 123})
 
 	duplicatedJob := *fxt.job
 	duplicatedJob.ID = util.NewUUID()
@@ -743,7 +782,7 @@ func TestAgentPreOfferingPopUp(t *testing.T) {
 	env.ethBack.TestCalled(t, "PopupServiceOffering", agentAddr,
 		env.worker.gasConf.PSC.PopupServiceOffering,
 		[common.HashLength]byte(offeringHash),
-		env.worker.somcType, env.worker.somcData)
+		data.OfferingSOMCShared, data.Base64String(""))
 
 	env.db.Reload(fxt.Offering)
 

--- a/proc/worker/worker.go
+++ b/proc/worker/worker.go
@@ -61,8 +61,7 @@ type Worker struct {
 	ethConfig      *eth.Config
 	countryConfig  *country.Config
 	pscPeriods     *eth.PSCPeriods
-	somcType       uint8
-	somcData       data.Base64String
+	torHostName    data.Base64String
 	torClient      *http.Client
 }
 
@@ -75,15 +74,6 @@ func NewWorker(logger log.Logger, db *reform.DB, somc *somc.Conn,
 	torHostname string, torSocksListener uint) (*Worker, error) {
 
 	l := logger.Add("type", "proc/worker.Worker")
-
-	somcType := data.OfferingSOMCShared
-	somcData := data.FromBytes([]byte(torHostname))
-	if len(somcData) > 0 {
-		l.Info("SOMC type Tor")
-		somcType = data.OfferingSOMCTor
-	} else {
-		l.Info("SOMC type Shared")
-	}
 
 	abi, err := abi.JSON(
 		strings.NewReader(contract.PrivatixServiceContractABI))
@@ -114,8 +104,7 @@ func NewWorker(logger log.Logger, db *reform.DB, somc *somc.Conn,
 		somc:           somc,
 		countryConfig:  countryConf,
 		pscPeriods:     pscPeriods,
-		somcType:       somcType,
-		somcData:       somcData,
+		torHostName:    data.FromBytes([]byte(torHostname)),
 		torClient:      torClient,
 	}, nil
 }


### PR DESCRIPTION
Add tor setting to dynamically control what somc type to use.
`AgentPreOfferingMsgBCPublish` and `AgentPreOfferingPopUp` - based on setting decides what somc type to use on publish.
`AgentPreEndpointMsgCreate` and `AgentAfterOfferingMsgBCPublish` - based on related offering's somc type decides whether to publish endpoint or not.