### PR TITLE
Remove FirstStartDelay to clientAfterOfferingMsgBCPublish job.

### DIFF
--- a/dappctrl-dev.config.json
+++ b/dappctrl-dev.config.json
@@ -128,7 +128,6 @@
                 "TryPeriod": 30000
             },
             "clientAfterOfferingMsgBCPublish": {
-                "FirstStartDelay": 30000,
                 "TryLimit": 10,
                 "TryPeriod": 60000
             },

--- a/dappctrl.config.json
+++ b/dappctrl.config.json
@@ -128,7 +128,6 @@
                 "TryPeriod": 30000
             },
             "clientAfterOfferingMsgBCPublish": {
-                "FirstStartDelay": 30000,
                 "TryLimit": 10,
                 "TryPeriod": 60000
             },


### PR DESCRIPTION
Resolves BV-1261.