### PR TITLE
Return "unitName" and "unitType" for getChannelUsage and getClientChannels UI RPC methods.

### DIFF
--- a/doc/ui/rpc.md
+++ b/doc/ui/rpc.md
@@ -499,7 +499,8 @@ curl -X POST -H "Content-Type: application/json" --data '{"method": "ui_getClien
                 "usage":{
                     "current":400,
                     "maxUsage":454,
-                    "unit":"units",
+                    "unitName":"MB",
+                    "unitType":"units",
                     "cost":8811
                 }
             }
@@ -545,7 +546,8 @@ curl -X POST -H "Content-Type: application/json" --data '{"method": "ui_getClien
                 "usage":{
                     "current":400,
                     "maxUsage":454,
-                    "unit":"units",
+                    "unitName":"MB",
+                    "unitType":"units",
                     "cost":8811
                 }
             }
@@ -602,7 +604,8 @@ curl -X POST -H "Content-Type: application/json" --data '{"method": "ui_getChann
     "result": {
                     "current":400,
                     "maxUsage":454,
-                    "unit":"units",
+                    "unitName":"MB",
+                    "unitType":"units",
                     "cost":8811
                 }
 }

--- a/ui/channel.go
+++ b/ui/channel.go
@@ -69,7 +69,8 @@ type jobBlock struct {
 type Usage struct {
 	Current  uint64 `json:"current"`
 	MaxUsage uint64 `json:"maxUsage"`
-	Unit     string `json:"unit"`
+	UnitName string `json:"unitName"`
+	UnitType string `json:"unitType"`
 	Cost     uint64 `json:"cost"`
 }
 
@@ -318,7 +319,8 @@ func newUsage(channel *data.Channel, offering *data.Offering,
 	result.Cost = cost
 	result.Current = usage
 	result.MaxUsage = deposit
-	result.Unit = offering.UnitType
+	result.UnitName = offering.UnitName
+	result.UnitType = offering.UnitType
 
 	return result
 }

--- a/ui/channel_test.go
+++ b/ui/channel_test.go
@@ -430,6 +430,11 @@ func checkClientChannelUsage(
 		t.Fatal("unsupported unit type")
 	}
 
+	if resp.Usage.UnitName != offer.UnitName {
+		t.Fatalf("expected %s, got: %s",
+			offer.UnitName, resp.Usage.UnitName)
+	}
+
 	if resp.Usage.Current != usage {
 		t.Fatalf("expected %d, got: %d",
 			usage, resp.Usage.Current)
@@ -484,7 +489,9 @@ func TestGetChannelUsage(t *testing.T) {
 	assertErrEqual(nil, err)
 
 	if ret == nil || ret.Current != expectedCurrentUsage ||
-		ret.MaxUsage != expectedMaxUsage || ret.Unit != offering.UnitType ||
+		ret.MaxUsage != expectedMaxUsage ||
+		ret.UnitName != offering.UnitName ||
+		ret.UnitType != offering.UnitType ||
 		ret.Cost != expectedCost {
 		t.Fatal("wrong channel usage")
 	}
@@ -500,7 +507,9 @@ func TestGetChannelUsage(t *testing.T) {
 	assertErrEqual(nil, err)
 
 	if ret == nil || ret.Current != expectedCurrentUsage ||
-		ret.MaxUsage != expectedMaxUsage || ret.Unit != offering.UnitType ||
+		ret.MaxUsage != expectedMaxUsage ||
+		ret.UnitName != offering.UnitName ||
+		ret.UnitType != offering.UnitType ||
 		ret.Cost != expectedCost {
 		t.Fatal("wrong channel usage")
 	}


### PR DESCRIPTION
Resolves BV-1280.