### PR TITLE
update gas limit, autopopup, error reporting

### DIFF
--- a/dappctrl-dev.config.json
+++ b/dappctrl-dev.config.json
@@ -63,24 +63,19 @@
     },
     "Gas": {
         "PSC": {
-            "AddBalanceERC20": 100000,
-            "BalanceOf": 100000,
-            "CooperativeClose": 200000,
-            "CreateChannel": 200000,
-            "GetChannelInfo": 100000,
-            "GetKey": 100000,
-            "PopupServiceOffering": 100000,
-            "PublishServiceOfferingEndpoint": 100000,
-            "RegisterServiceOffering": 200000,
-            "RemoveServiceOffering": 100000,
-            "ReturnBalanceERC20": 100000,
-            "SetNetworkFee": 100000,
-            "Settle": 100000,
-            "TopUp": 100000,
-            "UncooperativeClose": 100000
+            "AddBalanceERC20": 50818,
+            "CooperativeClose": 99070,
+            "CreateChannel": 75446,
+            "PopupServiceOffering": 42579,
+            "RegisterServiceOffering": 112941,
+            "RemoveServiceOffering": 25841,
+            "ReturnBalanceERC20": 48300,
+            "Settle": 54290,
+            "TopUp": 45836,
+            "UncooperativeClose": 72964
         },
         "PTC": {
-            "Approve": 100000
+            "Approve": 37905
         }
     },
     "Job": {
@@ -186,7 +181,7 @@
         "Workers": 0
     },
     "Looper": {
-        "AutoOfferingPopUpTimeout": 172800000
+        "AutoOfferingPopUpTimeout": 86400000
     },
     "NAT": {
         "CheckTimeout": 1000,

--- a/dappctrl-test.config.json
+++ b/dappctrl-test.config.json
@@ -57,24 +57,20 @@
     },
     "Gas": {
         "PSC": {
-            "AddBalanceERC20": 49412,
-            "BalanceOf": 23655,
-            "CooperativeClose": 97566,
-            "CreateChannel": 76797,
-            "GetChannelInfo": 29066,
-            "GetKey": 27310,
-            "PopupServiceOffering": 32674,
-            "PublishServiceOfferingEndpoint": 30528,
-            "RegisterServiceOffering": 95625,
-            "RemoveServiceOffering": 39238,
-            "ReturnBalanceERC20": 43417,
-            "SetNetworkFee": 27400,
-            "Settle": 41828,
-            "TopUp": 42065,
-            "UncooperativeClose": 56612
+            "AddBalanceERC20": 50818,
+            "CooperativeClose": 99070,
+            "CreateChannel": 75446,
+            "PopupServiceOffering": 42579,
+            "RegisterServiceOffering": 112941,
+            "RemoveServiceOffering": 25841,
+            "ReturnBalanceERC20": 48300,
+            "SetNetworkFee": 100000,
+            "Settle": 54290,
+            "TopUp": 45836,
+            "UncooperativeClose": 72964
         },
         "PTC": {
-            "Approve": 45375
+            "Approve": 37905
         }
     },
     "Job": {

--- a/dappctrl.config.json
+++ b/dappctrl.config.json
@@ -62,24 +62,20 @@
     },
     "Gas": {
         "PSC": {
-            "AddBalanceERC20": 100000,
-            "BalanceOf": 100000,
-            "CooperativeClose": 200000,
-            "CreateChannel": 200000,
-            "GetChannelInfo": 100000,
-            "GetKey": 100000,
-            "PopupServiceOffering": 100000,
-            "PublishServiceOfferingEndpoint": 100000,
-            "RegisterServiceOffering": 200000,
-            "RemoveServiceOffering": 100000,
-            "ReturnBalanceERC20": 100000,
+            "AddBalanceERC20": 50818,
+            "CooperativeClose": 99070,
+            "CreateChannel": 75446,
+            "PopupServiceOffering": 42579,
+            "RegisterServiceOffering": 112941,
+            "RemoveServiceOffering": 25841,
+            "ReturnBalanceERC20": 48300,
             "SetNetworkFee": 100000,
-            "Settle": 100000,
-            "TopUp": 100000,
-            "UncooperativeClose": 100000
+            "Settle": 54290,
+            "TopUp": 45836,
+            "UncooperativeClose": 72964
         },
         "PTC": {
-            "Approve": 100000
+            "Approve": 37905
         }
     },
     "Job": {
@@ -185,7 +181,7 @@
         "Workers": 0
     },
     "Looper": {
-        "AutoOfferingPopUpTimeout": 172800000
+        "AutoOfferingPopUpTimeout": 86400000
     },
     "PayAddress": "http://0.0.0.0:9000/v1/pmtChannel/pay",
     "PayServer": {

--- a/data/prod_data.sql
+++ b/data/prod_data.sql
@@ -60,7 +60,7 @@ DO NOTHING;
 
 INSERT INTO settings (key, value, permissions, description, name)
 VALUES ('error.sendremote',
-        'true',
+        'false',
         2,
         'Allow error reporting to send logs to Privatix.',
         'error reporting')

--- a/doc/config.md
+++ b/doc/config.md
@@ -128,13 +128,9 @@ Default gas limits for psc methods.
 |Field|Type|Description|Example|
 |-|-|-|-|
 |AddBalanceERC20|uint64||100000|
-|BalanceOf|uint64||100000|
 |CooperativeClose|uint64||100000|
 |CreateChannel|uint64||100000|
-|GetChannelInfo|uint64||100000|
-|GetKey|uint64||100000|
 |PopupServiceOffering|uint64||100000|
-|PublishServiceOfferingEndpoint|uint64||100000|
 |RegisterServiceOffering|uint64||100000|
 |RemoveServiceOffering|uint64||100000|
 |ReturnBalanceERC20|uint64||100000|
@@ -328,10 +324,6 @@ UI api server configuration.
             "UncooperativeClose": 100000,
             "Settle": 100000,
             "TopUp": 100000,
-            "GetChannelInfo": 100000,
-            "PublishServiceOfferingEndpoint": 100000,
-            "GetKey": 100000,
-            "BalanceOf": 100000,
             "PopupServiceOffering": 100000,
             "RemoveServiceOffering": 100000
         }

--- a/proc/worker/worker.go
+++ b/proc/worker/worker.go
@@ -24,21 +24,17 @@ type GasConf struct {
 		Approve uint64
 	}
 	PSC struct {
-		AddBalanceERC20                uint64
-		RegisterServiceOffering        uint64
-		CreateChannel                  uint64
-		CooperativeClose               uint64
-		ReturnBalanceERC20             uint64
-		SetNetworkFee                  uint64
-		UncooperativeClose             uint64
-		Settle                         uint64
-		TopUp                          uint64
-		GetChannelInfo                 uint64
-		PublishServiceOfferingEndpoint uint64
-		GetKey                         uint64
-		BalanceOf                      uint64
-		PopupServiceOffering           uint64
-		RemoveServiceOffering          uint64
+		AddBalanceERC20         uint64
+		RegisterServiceOffering uint64
+		CreateChannel           uint64
+		CooperativeClose        uint64
+		ReturnBalanceERC20      uint64
+		SetNetworkFee           uint64
+		UncooperativeClose      uint64
+		Settle                  uint64
+		TopUp                   uint64
+		PopupServiceOffering    uint64
+		RemoveServiceOffering   uint64
 	}
 }
 


### PR DESCRIPTION
- some gas limits were completely removed, as they apply to public smart-contract method, which doesn't require gas at all
- error reporting was disabled by default
- gas limit updated to be closer to real usage, while still having 10% to 30% margin