### PR TITLE
change 5555 port to 3452

### DIFF
--- a/dappctrl-dev.config.json
+++ b/dappctrl-dev.config.json
@@ -251,7 +251,7 @@
     },
     "Role": "agent",
     "SOMCServer": {
-        "Addr": "0.0.0.0:5555",
+        "Addr": "0.0.0.0:3452",
         "TLS": null
     },
     "Sess": {

--- a/dappctrl-test.config.json
+++ b/dappctrl-test.config.json
@@ -137,7 +137,7 @@
     },
     "Role": "agent",
     "SOMCServer": {
-        "Addr": "localhost:5555",
+        "Addr": "localhost:3452",
         "TLS": null
     },
     "SOMCTest": {

--- a/dappctrl.config.json
+++ b/dappctrl.config.json
@@ -245,7 +245,7 @@
     },
     "Role": "agent",
     "SOMCServer": {
-        "Addr": "localhost:5555",
+        "Addr": "localhost:3452",
         "TLS": null
     },
     "Sess": {

--- a/doc/config.md
+++ b/doc/config.md
@@ -212,7 +212,7 @@ Independent agent somc server. Intended to be shared via tor net. For agents onl
 
 |Field|Type|Description|Example|
 |-|-|-|-|
-|Addr|int|the agents somc server address|5555|
+|Addr|int|the agents somc server address|3452|
 |TLS|struct|Transport Layer Security settings| {"CertFile":"cert.pem","KeyFile": "key.pem"}| 
 
 ### SessionServer
@@ -358,7 +358,7 @@ UI api server configuration.
         "URL": "ws://89.38.96.53:8080"
     },
     "SOMCServer": {
-        "Addr": "localhost:5555",
+        "Addr": "localhost:3452",
         "TLS": null
     },
     "StaticPassword": "",


### PR DESCRIPTION
Android studio is often use `5555` port for Android Debug Bridge.
So, we should change it by default to `3452`